### PR TITLE
add slides for How To Shut Down Tolkien

### DIFF
--- a/pygotham-2014/videos/how-to-shut-down-tolkien.json
+++ b/pygotham-2014/videos/how-to-shut-down-tolkien.json
@@ -8,6 +8,9 @@
   "language": "eng",
   "quality_notes": "",
   "recorded": "2014-10-20",
+  "related_urls": [
+    "http://rhodesmill.org/brandon/slides/2014-08-pygotham/"
+  ],
   "slug": "how-to-shut-down-tolkien",
   "speakers": [
     "Brandon Rhodes"


### PR DESCRIPTION
This adds slides as a related link for Brandon's talk on How To Shut Down Tolkien.