### PR TITLE
Fix PyCon SE 2016 recorded dates + Add Armin R. 2nd Keynote

### DIFF
--- a/pycon-se-2016/videos/armin-ronacher-keynote-2016-05-10.json
+++ b/pycon-se-2016/videos/armin-ronacher-keynote-2016-05-10.json
@@ -1,0 +1,22 @@
+{
+  "copyright_text": "Standard YouTube License",
+  "description": "Armin Ronacher Keynote",
+  "duration": 3367,
+  "language": "eng",
+  "recorded": "2016-05-10",
+  "related_urls": [],
+  "speakers": [
+    "Armin Ronacher"
+  ],
+  "tags": [
+    "Keynote"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/ICEbze5xy4s/maxresdefault.jpg",
+  "title": "Keynote 2016-05-10",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=ICEbze5xy4s"
+    }
+  ]
+}

--- a/pycon-se-2016/videos/armin-ronacher-keynote-happiness-in-open-source.json
+++ b/pycon-se-2016/videos/armin-ronacher-keynote-happiness-in-open-source.json
@@ -12,7 +12,7 @@
     "Keynote"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/lQz0oFQgAf4/maxresdefault.jpg",
-  "title": "Happiness in Open Source",
+  "title": "Happiness in Open Source (Impromptu Keynote)",
   "videos": [
     {
       "type": "youtube",

--- a/pycon-se-2016/videos/davey-shafik-http2-and-asynchronous-apis.json
+++ b/pycon-se-2016/videos/davey-shafik-http2-and-asynchronous-apis.json
@@ -3,7 +3,7 @@
   "description": "HTTP/2 (H2) is coming, and along with it a whole new way of communicating over the web. Connection re-use, prioritization, multiplexing, and server push are just some of the features we'll look at in H2.",
   "duration": 1726,
   "language": "eng",
-  "recorded": "2016-05-30",
+  "recorded": "2016-05-09",
   "related_urls": [],
   "speakers": [
     "Davey Shafik"

--- a/pycon-se-2016/videos/dennis-ljungmark-introduction-to-crypto-tls-pki-and-x509.json
+++ b/pycon-se-2016/videos/dennis-ljungmark-introduction-to-crypto-tls-pki-and-x509.json
@@ -3,7 +3,7 @@
   "description": "I'll walk through the basics of Cryptography, an up high view of TLS and x509, and then delve down into setting it up with Let's Encrypt domain validation and a Python microservice.",
   "duration": 2712,
   "language": "eng",
-  "recorded": "2016-05-25",
+  "recorded": "2016-05-09",
   "related_urls": [],
   "speakers": [
     "Dennis Ljungmark"

--- a/pycon-se-2016/videos/dustin-whittle-performance-testing-for-modern-apps.json
+++ b/pycon-se-2016/videos/dustin-whittle-performance-testing-for-modern-apps.json
@@ -3,7 +3,7 @@
   "description": "Dustin Whittle shares the latest techniques and tools for performance testing modern web and mobile applications. Join this session and learn how to capacity plan and evaluate performance and the scalability of the server-side through Siege, Bees with Machine Guns, and Locust.io. We will dive into modern performance testing on the client-side and how to leverage navigation/resource timing apis and tools like Google PageSpeed and SiteSpeed.io to understand the real world performance of your users.",
   "duration": 1950,
   "language": "eng",
-  "recorded": "2016-06-07",
+  "recorded": "2016-05-09",
   "related_urls": [],
   "speakers": [
     "Dustin Whittle"

--- a/pycon-se-2016/videos/erik-rehn-deep-python-learning-with-tensorflow-a-data-driven-approach-to-python-execution.json
+++ b/pycon-se-2016/videos/erik-rehn-deep-python-learning-with-tensorflow-a-data-driven-approach-to-python-execution.json
@@ -3,7 +3,7 @@
   "description": "Is it possible to train a neural network to execute Python scripts?\n\nData-driven algorithm learning is a growing field of research. In this talk we will take a look at Google\u2019s new deep learning library Tensorflow, and implement a basic model that can be taught how to execute simple Python scripts.",
   "duration": 1928,
   "language": "eng",
-  "recorded": "2016-05-25",
+  "recorded": "2016-05-09",
   "related_urls": [],
   "speakers": [
     "Erik Rehn"

--- a/pycon-se-2016/videos/eyad-sibai-no-need-to-spark-when-you-can-dask.json
+++ b/pycon-se-2016/videos/eyad-sibai-no-need-to-spark-when-you-can-dask.json
@@ -3,7 +3,7 @@
   "description": "In this talk we cover the what, the how and the why of Dask. we discuss the design behind dask which is blocking algorithms and task scheduling. Show examples of dask collections and how to use them. Compare dask to other alternatives.",
   "duration": 2231,
   "language": "eng",
-  "recorded": "2016-05-25",
+  "recorded": "2016-05-10",
   "related_urls": [],
   "speakers": [
     "Eyad Sibai"

--- a/pycon-se-2016/videos/henrik-blidh-the-point-of-pointless-projects.json
+++ b/pycon-se-2016/videos/henrik-blidh-the-point-of-pointless-projects.json
@@ -3,7 +3,7 @@
   "description": "Does your spare time coding projects haunt your every waking moment? Have they grown beyond all reasonable boundaries? This is a talk about a three-year odyssey into spare time Python coding, focusing on unexpected but beneficial spin-offs that seemingly meaningless projects can have; from Sudoku solvers to Raspberry Pi prototypes.",
   "duration": 1252,
   "language": "eng",
-  "recorded": "2016-05-25",
+  "recorded": "2016-05-09",
   "related_urls": [],
   "speakers": [
     "Henrik Blidh"

--- a/pycon-se-2016/videos/igor-mosyagin-python-in-science-a-case-study.json
+++ b/pycon-se-2016/videos/igor-mosyagin-python-in-science-a-case-study.json
@@ -3,7 +3,7 @@
   "description": "A short introduction on python adoption in scientific community given from the perspective of a PhD student in theoretical physics. Inevitably segueing towards why and how we should influence the current state.",
   "duration": 2220,
   "language": "eng",
-  "recorded": "2016-05-30",
+  "recorded": "2016-05-09",
   "related_urls": [],
   "speakers": [
     "Igor Mosyagin"

--- a/pycon-se-2016/videos/jessica-mckellar-keynote.json
+++ b/pycon-se-2016/videos/jessica-mckellar-keynote.json
@@ -12,7 +12,7 @@
     "Keynote"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/C0fnHhY9UOc/maxresdefault.jpg",
-  "title": "2016-05-10 Keynote",
+  "title": "Breaking the rules (Keynote)",
   "videos": [
     {
       "type": "youtube",

--- a/pycon-se-2016/videos/joakim-karlsson-guided-by-tests-what-your-unit-tests-can-tell-about-your-design.json
+++ b/pycon-se-2016/videos/joakim-karlsson-guided-by-tests-what-your-unit-tests-can-tell-about-your-design.json
@@ -3,7 +3,7 @@
   "description": "We'll explore how our unit tests changed our design to become more adaptable once we started to listen to what they had to say. We'll go through a couple of functions and their tests and show how we step by step transformed them into something a lot easier to handle.",
   "duration": 2429,
   "language": "eng",
-  "recorded": "2016-05-30",
+  "recorded": "2016-05-10",
   "related_urls": [],
   "speakers": [
     "Joakim Karlsson"

--- a/pycon-se-2016/videos/julian-berman-introduction-to-json-schema.json
+++ b/pycon-se-2016/videos/julian-berman-introduction-to-json-schema.json
@@ -3,7 +3,7 @@
   "description": "JSON Schema is an increasingly popular, cross-language specification for schematization of JSON documents. It represents schema constraints on a JSON document *as* a JSON document, in a flexible validation language. We'll investigate some simple (and not so simple) examples of data validation using the `jsonschema` Python package, which implements the specification.",
   "duration": 2453,
   "language": "eng",
-  "recorded": "2016-05-30",
+  "recorded": "2016-05-10",
   "related_urls": [],
   "speakers": [
     "Julian Berman"

--- a/pycon-se-2016/videos/k-rain-leander-build-a-private-developers-cloud-using-tripleo.json
+++ b/pycon-se-2016/videos/k-rain-leander-build-a-private-developers-cloud-using-tripleo.json
@@ -3,7 +3,7 @@
   "description": "TripleO is an OpenStack Deployment & Management tool built using python. The Cloud, Big Data, Internet of Things \u2013 so many technologies are the new hotness right now and TripleO quickstart is one of many ways to dive into one of the largest open source umbrella project, OpenStack.",
   "duration": 2000,
   "language": "eng",
-  "recorded": "2016-05-30",
+  "recorded": "2016-05-10",
   "related_urls": [],
   "speakers": [
     "K Rain Leander"

--- a/pycon-se-2016/videos/magnus-hagander-enhancing-your-python-database-experience-with-postgresql.json
+++ b/pycon-se-2016/videos/magnus-hagander-enhancing-your-python-database-experience-with-postgresql.json
@@ -3,7 +3,7 @@
   "description": "Python is a great programming language, and PostgreSQL is a great database. That's an overlap too good not to exploit! This talk will give an overview of how to use some of the PostgreSQL specific extensions in Python, to make your applications both easier and more powerful.",
   "duration": 3547,
   "language": "eng",
-  "recorded": "2016-05-25",
+  "recorded": "2016-05-09",
   "related_urls": [],
   "speakers": [
     "Magnus Hagander"

--- a/pycon-se-2016/videos/mondays-lightning-talks.json
+++ b/pycon-se-2016/videos/mondays-lightning-talks.json
@@ -3,7 +3,7 @@
   "description": "Lightning talks",
   "duration": 2950,
   "language": "eng",
-  "recorded": "2016-06-07",
+  "recorded": "2016-05-09",
   "related_urls": [],
   "speakers": [
     "Various speakers"

--- a/pycon-se-2016/videos/pj-hagerty-urban-legends-what-you-code-makes-you-who-you-are.json
+++ b/pycon-se-2016/videos/pj-hagerty-urban-legends-what-you-code-makes-you-who-you-are.json
@@ -3,7 +3,7 @@
   "description": "Tools are just a means to an end. So why do developers think the language they use defines the problems they solve.\n\nThis talk will take a look at misconceptions across the board, some experiences, both positive and negative, people have had crossing barriers to new languages, and show some of the benefits thinking of one's self as a coder and not a \"Ruby coder\" or a \"Python dev\" can have on being a better problem solver.",
   "duration": 2349,
   "language": "eng",
-  "recorded": "2016-05-30",
+  "recorded": "2016-05-10",
   "related_urls": [],
   "speakers": [
     "PJ Hagerty"

--- a/pycon-se-2016/videos/ruben-orduz-a-better-user-experience-in-the-command-line.json
+++ b/pycon-se-2016/videos/ruben-orduz-a-better-user-experience-in-the-command-line.json
@@ -3,7 +3,7 @@
   "description": "Have you used `openssl`? The ubiquitous `curl`? What do they have in common? \n\nVery confusing, unclear arguments, unhelpful docs and sometimes outright impossible to use without Googling first. \n\nIn this talk I will show you why this is the case and how to avoid them on your command-line tool.",
   "duration": 1670,
   "language": "eng",
-  "recorded": "2016-05-25",
+  "recorded": "2016-05-09",
   "related_urls": [],
   "speakers": [
     "Ruben Orduz"

--- a/pycon-se-2016/videos/tuesdays-lightning-talks.json
+++ b/pycon-se-2016/videos/tuesdays-lightning-talks.json
@@ -3,7 +3,7 @@
   "description": "Lightning Talks",
   "duration": 1931,
   "language": "eng",
-  "recorded": "2016-05-30",
+  "recorded": "2016-05-10",
   "related_urls": [],
   "speakers": [
     "Various speakers"


### PR DESCRIPTION
I noticed that the dates for PyCon SE 2016 did not match the events dates which [was on May 9-10, 2016](http://www.pycon.se/)

I also found that Armin Ronacher actually gave 2 talks, because YouTube suggested be https://www.youtube.com/watch?v=ICEbze5xy4s while watching https://www.youtube.com/watch?v=lQz0oFQgAf4

I also changed Jessica McKellar Keynote's title, using the title you can see on the slides.