### PR TITLE
Add filename to render_rest script error reporting even in non-verbose mode

### DIFF
--- a/.tests/render_rest.py
+++ b/.tests/render_rest.py
@@ -64,10 +64,11 @@ def check_render_rest(data_root, verbose=False):
                 if error and level >= INVALID_ERROR_LEVEL:
                     valid = False
 
-                if error and verbose:
-                    msg = 'ReST validation error:\n\tFile:{}\n\tKey:{}'
+                if error:
+                    msg = 'ReST validation error:\n\tFile: {}\n\tKey: {}'
                     print(msg.format(file_path, field), flush=True)
-                    print('\t', error, sep='', flush=True)
+                    if verbose:
+                        print('\t', error, sep='', flush=True)
 
     if not valid:
         sys.exit(1)


### PR DESCRIPTION
Somehow I had trouble reproducing the error on render-rest test [that Travis was reporting here](https://travis-ci.org/pyvideo/data/builds/183081752):
```
python3 /home/travis/build/pyvideo/data/.tests/schemas.py -d /home/travis/build/pyvideo/data -s /home/travis/build/pyvideo/data/.schemas -v 0
python3 /home/travis/build/pyvideo/data/.tests/ids_unique.py -d /home/travis/build/pyvideo/data
python3 /home/travis/build/pyvideo/data/.tests/slugs_unique.py -d /home/travis/build/pyvideo/data
python3 /home/travis/build/pyvideo/data/.tests/render_rest.py -d /home/travis/build/pyvideo/data
:8: (WARNING/2) Inline emphasis start-string without end-string.
make: *** [test-render-rest] Error 1
```

So I'm suggesting that the script also outputs the file that is having issues even in non-verbose mode so that it appears in Travis logs