### PR TITLE
Add error-level info on ReST validation error messages

### DIFF
--- a/.tests/render_rest.py
+++ b/.tests/render_rest.py
@@ -65,8 +65,8 @@ def check_render_rest(data_root, verbose=False):
                     valid = False
 
                 if error:
-                    msg = 'ReST validation error:\n\tFile: {}\n\tKey: {}'
-                    print(msg.format(file_path, field), flush=True)
+                    msg = 'ReST validation error (level {level}):\n\tFile: {fp}\n\tKey: {key}'
+                    print(msg.format(fp=file_path, key=field, level=level), flush=True)
                     if verbose:
                         print('\t', error, sep='', flush=True)
 


### PR DESCRIPTION
Adding level info to validation error logs so as to point to errors vs. info.
I got confused when trying to fix https://travis-ci.org/pyvideo/data/builds/185018129