### PR TITLE
Data cleanup - blank names

### DIFF
--- a/pycon-us-2009/videos/pycon-2009--a-curious-course-on-coroutines-and-c0.json
+++ b/pycon-us-2009/videos/pycon-2009--a-curious-course-on-coroutines-and-c0.json
@@ -9,7 +9,7 @@
   "quality_notes": "",
   "recorded": null,
   "slug": "pycon-2009--a-curious-course-on-coroutines-and-c0",
-  "speakers": [],
+  "speakers": ["David Beazley"],
   "summary": "",
   "tags": [
     "concurrency",

--- a/pycon-us-2009/videos/pycon-2009--a-curious-course-on-coroutines-and-c1.json
+++ b/pycon-us-2009/videos/pycon-2009--a-curious-course-on-coroutines-and-c1.json
@@ -9,7 +9,7 @@
   "quality_notes": "",
   "recorded": null,
   "slug": "pycon-2009--a-curious-course-on-coroutines-and-c1",
-  "speakers": [],
+  "speakers": ["David Beazley"],
   "summary": "",
   "tags": [
     "concurrency",


### PR DESCRIPTION
I noticed some of the videos in Pycon 2009 were missing the names of the speakers - I updated the json files for parts 2 and 3 of David Beazley's Curious Coroutines.