### PR TITLE
Added tags to this video

### DIFF
--- a/pycon-us-2016/videos/michael-tom-wing-christie-wilson-introduction-to-unit-testing-in-python-with-pytest-pycon-2016.json
+++ b/pycon-us-2016/videos/michael-tom-wing-christie-wilson-introduction-to-unit-testing-in-python-with-pytest-pycon-2016.json
@@ -14,7 +14,10 @@
     "Michael Tom-Wing",
     "Christie Wilson"
   ],
-  "tags": [],
+  "tags": [
+    "pytest",
+    "testing"
+  ],
   "thumbnail_url": "https://i.ytimg.com/vi/UPanUFVFfzY/maxresdefault.jpg",
   "title": "Introduction to Unit Testing in Python with Pytest",
   "videos": [


### PR DESCRIPTION
During an online chat on [Pytest](https://www.crowdcast.io/e/pytest), someone noticed that NEWER pytest-related videos weren't being found by the "pytest" tag. I've fixed this video. I'll try to look for others.