### PR TITLE
Summarize lightning-talks-may-19-evening-session

### DIFF
--- a/pycon-us-2017/videos/lightning-talks-may-19th-2017-evening-session.json
+++ b/pycon-us-2017/videos/lightning-talks-may-19th-2017-evening-session.json
@@ -5,6 +5,7 @@
   "speakers": [
     "Various speakers"
   ],
+  "summary": "======   =====================   ==================================================\nStart    Speakers                Subject                                 \n======   =====================   ==================================================\n0m49s    J. Pan & C. Lin         ZulipBot - Improving GitHub Workflow\nAdd Issue Assignment, better Notifications,\nand other improvements to GitHub.\n\n6m23s    Lennart                 Your Keyboard:  Your Most Important Tool\nEliminating angle issues and space problems\nwith angled, tenkeyless keyboards, stretches,\nand more keyboard geekery.\n\n11m37s   Hugo Herter             Live code reloading in Python\nUsing the module autoreload to watch and \nreload during debugging.\n\n16m11s   Don Goodman-Wilson      Pascal's Wager and You\nPascal's Wager on the Existence of God is \nequivalent to wagering about a debilitating hack.\n20m27s   Paul Ganssle            Time Zone Tools\nLooking at datettime, tzinfo, dateutil and pytz, \ncommon errors, and timezone geekery.\n\n25m41s   Paul & Luara            State of PyVideo.org\nCurrent website, traffic, and users.  \n======   =====================   ==================================================\n\n",
   "tags": [
     "lightning talks"
   ],


### PR DESCRIPTION
Add summary field listing each lightning talk, time of start in the video, and description.   All in a single line as required by the JSON specification.