### PR TITLE
corrected tags

### DIFF
--- a/pycon-us-2009/videos/pycon-2009--plenary--morning-lightning-talks.json
+++ b/pycon-us-2009/videos/pycon-2009--plenary--morning-lightning-talks.json
@@ -13,7 +13,7 @@
     "Adam Fast",
     "Charles Severance",
     "Christopher Allan Webber",
-    "JIm Fulton",
+    "Jim Fulton",
     "John Hampton",
     "John Mulder",
     "Justin Bronn",
@@ -25,7 +25,6 @@
   "summary": "Plenary: Morning Lightning Talks covering GeoDjango, Zope, Launchpad,\nJSOT, AppEngine, StackOverflow, Miro, zc.buildout and RPM, ham radio,\nPlyne, GozerBot, picking tools, and stop watch.\n",
   "tags": [
     "appengine",
-    "chriswebber",
     "geodjango",
     "informatics",
     "jsqt",
@@ -37,7 +36,7 @@
     "pycon",
     "pycon2009",
     "pylons",
-    "stackoverflow",
+    "stack overflow",
     "zc.buildout",
     "zope"
   ],


### PR DESCRIPTION
Speaker names should not be tags, they belong in the speaker item/object; adjusted 'stackoverflow' to 'stack overflow' to fit new tag standard