### PR TITLE
Tell Travis CI how to install before running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
 - '3.5'
+install: make install-deps
 script: make test
 


### PR DESCRIPTION
This just makes it nicer to navigate the Travis CI interface.