### PR TITLE
DjangoCon Europe 2017 tweaks

### DIFF
--- a/djangocon-eu-2017/category.json
+++ b/djangocon-eu-2017/category.json
@@ -1,5 +1,4 @@
 {
-  "description": "",
   "title": "DjangoCon Europe 2017",
   "url": "https://2017.djangocon.eu/"
 }

--- a/djangocon-eu-2017/videos/all-about-community-panel-with-anna-makarudze-anna-ossowski-erik-romjin-russel-keith-magee.json
+++ b/djangocon-eu-2017/videos/all-about-community-panel-with-anna-makarudze-anna-ossowski-erik-romjin-russel-keith-magee.json
@@ -9,6 +9,7 @@
     "Anna Ossowski",
     "Anna Makarudze"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/dALTqTkIZVE/hqdefault.jpg",
   "title": "All about community panel",
   "videos": [

--- a/djangocon-eu-2017/videos/autopsy-of-a-slow-train-wreck-the-life-and-death-of-a-django-startup-by-russell-keith-magee.json
+++ b/djangocon-eu-2017/videos/autopsy-of-a-slow-train-wreck-the-life-and-death-of-a-django-startup-by-russell-keith-magee.json
@@ -4,11 +4,15 @@
   "language": "eng",
   "recorded": "2017-04-04",
   "related_urls": [
-    "https://2017.djangocon.eu/media/filer_public/18/96/18960236-6a96-4695-841c-607a18ddf7b4/train_wreck.pdf"
+    {
+      "label": "slides",
+      "url": "https://2017.djangocon.eu/media/filer_public/18/96/18960236-6a96-4695-841c-607a18ddf7b4/train_wreck.pdf"
+    }
   ],
   "speakers": [
     "Dr. Russell Keith-Magee"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/DnR9PZS5WGE/hqdefault.jpg",
   "title": "Autopsy of a slow train wreck: The life and death of a Django startup",
   "videos": [

--- a/djangocon-eu-2017/videos/closing-ceremony.json
+++ b/djangocon-eu-2017/videos/closing-ceremony.json
@@ -7,6 +7,7 @@
     "Iacopo Spalletti",
     "Emanuela Dal Mas"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/wFGRiXDZMb4/hqdefault.jpg",
   "title": "Closing ceremony",
   "videos": [

--- a/djangocon-eu-2017/videos/data-internationalization-in-django-by-raphael-michel.json
+++ b/djangocon-eu-2017/videos/data-internationalization-in-django-by-raphael-michel.json
@@ -4,11 +4,15 @@
   "language": "eng",
   "recorded": "2017-04-04",
   "related_urls": [
-    "https://speakerdeck.com/raphaelm/data-internationalization-in-django"
+    {
+      "label": "slides",
+      "url": "https://speakerdeck.com/raphaelm/data-internationalization-in-django"
+    }
   ],
   "speakers": [
     "Raphael Michel"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/vdbpinOmMeo/hqdefault.jpg",
   "title": "Data internationalization in Django",
   "videos": [

--- a/djangocon-eu-2017/videos/defining-a-customizable-boilerplate-using-django-react-and-bootstrap-by-lais-varejao.json
+++ b/djangocon-eu-2017/videos/defining-a-customizable-boilerplate-using-django-react-and-bootstrap-by-lais-varejao.json
@@ -4,11 +4,15 @@
   "language": "eng",
   "recorded": "2017-04-05",
   "related_urls": [
-    "https://docs.google.com/presentation/d/15Jcf3HBko0qzE7HY411-4RjVDiCiPeEZlZbipTo7K50/edit#slide=id.p"
+    {
+      "label": "slides",
+      "url": "https://docs.google.com/presentation/d/15Jcf3HBko0qzE7HY411-4RjVDiCiPeEZlZbipTo7K50/edit#slide=id.p"
+    }
   ],
   "speakers": [
     "Lais Varejao"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/uog1q8J_MQY/hqdefault.jpg",
   "title": "Defining a customizable boilerplate using Django, React and Bootstrap",
   "videos": [

--- a/djangocon-eu-2017/videos/dial-m-for-mentor-by-mariatta-wijaya.json
+++ b/djangocon-eu-2017/videos/dial-m-for-mentor-by-mariatta-wijaya.json
@@ -3,11 +3,15 @@
   "duration": 1585,
   "recorded": "2017-04-05",
   "related_urls": [
-    "https://2017.djangocon.eu/media/filer_public/3a/32/3a3247f3-1ced-47db-b5eb-734ca30c0e33/dial_m_for_mentor_-_djangoconeu.pdf"
+    {
+      "label": "slides",
+      "url": "https://2017.djangocon.eu/media/filer_public/3a/32/3a3247f3-1ced-47db-b5eb-734ca30c0e33/dial_m_for_mentor_-_djangoconeu.pdf"
+    }
   ],
   "speakers": [
     "Mariatta Wijaya"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/gAH0PbtHrMU/hqdefault.jpg",
   "title": "Dial M For Mentor",
   "videos": [

--- a/djangocon-eu-2017/videos/django-and-the-testing-pyramid-by-aaron-bassett.json
+++ b/djangocon-eu-2017/videos/django-and-the-testing-pyramid-by-aaron-bassett.json
@@ -6,6 +6,7 @@
   "speakers": [
     "Aaron Bassett"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/Mb4P0vnmymM/hqdefault.jpg",
   "title": "Django and the testing pyramid",
   "videos": [

--- a/djangocon-eu-2017/videos/djangos-watching-my-backend-by-carlos-de-las-heras.json
+++ b/djangocon-eu-2017/videos/djangos-watching-my-backend-by-carlos-de-las-heras.json
@@ -4,11 +4,15 @@
   "language": "eng",
   "recorded": "2017-04-03",
   "related_urls": [
-    "https://speakerdeck.com/cahersan/djangos-watching-my-back-end"
+    {
+      "label": "slides",
+      "url": "https://speakerdeck.com/cahersan/djangos-watching-my-back-end"
+    }
   ],
   "speakers": [
-    "Carlos De Las Heras"
+    "Carlos de las Heras"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/D2WN0zLIXz4/hqdefault.jpg",
   "title": "Django is watching my back(end)",
   "videos": [

--- a/djangocon-eu-2017/videos/docker-lessons-from-real-world-projects-by-rivo-lask.json
+++ b/djangocon-eu-2017/videos/docker-lessons-from-real-world-projects-by-rivo-lask.json
@@ -4,11 +4,15 @@
   "language": "eng",
   "recorded": "2017-04-05",
   "related_urls": [
-    "https://speakerdeck.com/rivolaks/docker-lessons-from-real-world-projects"
+    {
+      "label": "slides",
+      "url": "https://speakerdeck.com/rivolaks/docker-lessons-from-real-world-projects"
+    }
   ],
   "speakers": [
     "Rivo Lask"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/-OLEdtpELl8/hqdefault.jpg",
   "title": "Docker Lessons from Real-World Projects",
   "videos": [

--- a/djangocon-eu-2017/videos/fighting-the-controls-madness-for-programmers-by-daniele-procida.json
+++ b/djangocon-eu-2017/videos/fighting-the-controls-madness-for-programmers-by-daniele-procida.json
@@ -6,6 +6,7 @@
   "speakers": [
     "Daniele Procida"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/k9exZZZCTUk/hqdefault.jpg",
   "title": "Fighting the controls - madness for programmers",
   "videos": [

--- a/djangocon-eu-2017/videos/floods-list-database-by-maurizio-latini.json
+++ b/djangocon-eu-2017/videos/floods-list-database-by-maurizio-latini.json
@@ -1,14 +1,22 @@
 {
-  "description": "As a first step we worked with FloodList.com to integrate their observations collated from media reports into a database hosted at the European Centre for Medium Range Weather Forecasts (ECMWF). \nFloodList.com provide the data in json format via an API which is then queried on a daily basis to update the ECMWF hosted database. \n\nA web interface is being developed to allow users to visualise and query the database, examples queries include the time period, season, location and flood type. \nAll the results of the queries are displayed on a WebMap so is it possible to locate the point on a geographical context.\nThe architecture of the system is based on a Django 'light' layer that runs on top of the ECMWF web infrastructure. Through an orchestrator all the requests are dispatched to some python based services that performs the computations and return the results to the Django layer that uses some templates to visualise the results.\n\nThese resources could be useful for contextualisation studies of the risk posed to exposed populations who inhabit flood prone areas. They will also be useful for the verification of the growing number of global and continental flood forecasting systems. Future developments include the addition of different data sources to the database as well as the integration of the web interface into the Global Flood Awareness System [GloFAS] website. With this integration we aim to encourage directly report flood events through an online form.",
+  "description": "As a first step we worked with FloodList.com to integrate their observations collated from media reports into a database hosted at the European Centre for Medium Range Weather Forecasts (ECMWF).\nFloodList.com provide the data in json format via an API which is then queried on a daily basis to update the ECMWF hosted database.\n\nA web interface is being developed to allow users to visualise and query the database, examples queries include the time period, season, location and flood type.\nAll the results of the queries are displayed on a WebMap so is it possible to locate the point on a geographical context.\nThe architecture of the system is based on a Django 'light' layer that runs on top of the ECMWF web infrastructure. Through an orchestrator all the requests are dispatched to some python based services that performs the computations and return the results to the Django layer that uses some templates to visualise the results.\n\nThese resources could be useful for contextualisation studies of the risk posed to exposed populations who inhabit flood prone areas. They will also be useful for the verification of the growing number of global and continental flood forecasting systems. Future developments include the addition of different data sources to the database as well as the integration of the web interface into the Global Flood Awareness System [GloFAS] website. With this integration we aim to encourage directly report flood events through an online form.",
   "duration": 1464,
   "language": "eng",
   "recorded": "2017-04-04",
   "related_urls": [
-    "https://2017.djangocon.eu/filer_public/ed/b7/edb7e402-3930-4f23-adcb-4369665f047f/djangocon_firenze_2017_7.pptx"
+    {
+      "label": "slides",
+      "url": "https://2017.djangocon.eu/filer_public/ed/b7/edb7e402-3930-4f23-adcb-4369665f047f/djangocon_firenze_2017_7.pptx"
+    },
+    {
+      "label": "FloodList",
+      "url": "http://floodlist.com/"
+    }
   ],
   "speakers": [
     "Maurizio Latini"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/NbghPf939hg/hqdefault.jpg",
   "title": "Floods List database",
   "videos": [

--- a/djangocon-eu-2017/videos/including-women-in-technology-fostering-diversity.json
+++ b/djangocon-eu-2017/videos/including-women-in-technology-fostering-diversity.json
@@ -11,6 +11,7 @@
     "Flavia Weisghizzi",
     "Kriti Mehta"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/VbVFFd0Jswo/hqdefault.jpg",
   "title": "Including women in technology, fostering diversity",
   "videos": [

--- a/djangocon-eu-2017/videos/last-mile-django-by-tom-wier.json
+++ b/djangocon-eu-2017/videos/last-mile-django-by-tom-wier.json
@@ -6,6 +6,7 @@
   "speakers": [
     "Tom Wier"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/gt8nbKuQmPs/hqdefault.jpg",
   "title": "Last Mile Django",
   "videos": [

--- a/djangocon-eu-2017/videos/level-up-rethinking-the-web-api-framework-by-tom-christie.json
+++ b/djangocon-eu-2017/videos/level-up-rethinking-the-web-api-framework-by-tom-christie.json
@@ -1,14 +1,18 @@
 {
-  "description": "Think there's nothing left to explore in how we design Web API frameworks? Think again.\n\nThe author of Django REST framework walks through how we might approach designing a new Python-based API framework from scratch, and looks at how we can start building smarter, more productive API tooling as a result.\n\nYou should come away from this talk with a better appreciation of:\n\nHow best to provide API client libraries and API documentation to your users.\nHow to build APIs that support both realtime and request/response interfaces.\nHow to build APIs that are web-browsable.\nWhy you might want to consider taking a schema-first approach to your API design.",
+  "description": "Think there's nothing left to explore in how we design Web API frameworks? Think again.\n\nThe author of Django REST framework walks through how we might approach designing a new Python-based API framework from scratch, and looks at how we can start building smarter, more productive API tooling as a result.\n\nYou should come away from this talk with a better appreciation of:\n\n* How best to provide API client libraries and API documentation to your users.\n* How to build APIs that support both realtime and request/response interfaces.\n* How to build APIs that are web-browsable.\n* Why you might want to consider taking a schema-first approach to your API design.",
   "duration": 1598,
   "language": "eng",
   "recorded": "2017-04-03",
   "related_urls": [
-    "http://www.encode.io/talks/rethinking-the-web-api-framework/assets/player/KeynoteDHTMLPlayer.html#0"
+    {
+      "label": "slides",
+      "url": "http://www.encode.io/talks/rethinking-the-web-api-framework/assets/player/KeynoteDHTMLPlayer.html#0"
+    }
   ],
   "speakers": [
     "Tom Christie"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/zeOogB4qfow/hqdefault.jpg",
   "title": "Level up! Rethinking the Web API framework",
   "videos": [

--- a/djangocon-eu-2017/videos/lighting-talks-monday.json
+++ b/djangocon-eu-2017/videos/lighting-talks-monday.json
@@ -7,6 +7,9 @@
     "Peter Bittner",
     "Jacob Rief"
   ],
+  "tags": [
+    "lighting talks"
+  ],
   "thumbnail_url": "https://i.ytimg.com/vi/-kL9YgMCOSk/hqdefault.jpg",
   "title": "Lighting talks - Monday",
   "videos": [

--- a/djangocon-eu-2017/videos/lighting-talks-tuesday.json
+++ b/djangocon-eu-2017/videos/lighting-talks-tuesday.json
@@ -11,6 +11,9 @@
     "Sergei Maertens",
     "Antonis Christofides"
   ],
+  "tags": [
+    "lighting talks"
+  ],
   "thumbnail_url": "https://i.ytimg.com/vi/S8j8fMpiUfk/hqdefault.jpg",
   "title": "Lighting talks - Tuesday",
   "videos": [

--- a/djangocon-eu-2017/videos/lighting-talks-wednesday-part-1.json
+++ b/djangocon-eu-2017/videos/lighting-talks-wednesday-part-1.json
@@ -10,6 +10,9 @@
     "Chris Adams",
     "Patrick Arminio"
   ],
+  "tags": [
+    "lighting talks"
+  ],
   "thumbnail_url": "https://i.ytimg.com/vi/Hg9IMVBHPAk/hqdefault.jpg",
   "title": "Lighting talks - Wednesday - part 1",
   "videos": [

--- a/djangocon-eu-2017/videos/lighting-talks-wednesday-part-2.json
+++ b/djangocon-eu-2017/videos/lighting-talks-wednesday-part-2.json
@@ -16,6 +16,9 @@
     "Galena",
     "Pawel Sierszen"
   ],
+  "tags": [
+    "lighting talks"
+  ],
   "thumbnail_url": "https://i.ytimg.com/vi/RoleIxRyU5w/hqdefault.jpg",
   "title": "Lighting talks - Wednesday - part 2",
   "videos": [

--- a/djangocon-eu-2017/videos/marketing-for-developers-by-tracy-osborn.json
+++ b/djangocon-eu-2017/videos/marketing-for-developers-by-tracy-osborn.json
@@ -4,11 +4,15 @@
   "language": "eng",
   "recorded": "2017-04-04",
   "related_urls": [
-    "https://speakerdeck.com/limedaring/pycaribbean-1"
+    {
+      "label": "slides",
+      "url": "https://speakerdeck.com/limedaring/pycaribbean-1"
+    }
   ],
   "speakers": [
     "Tracy Osborn"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/PL2oDxRbO6k/hqdefault.jpg",
   "title": "Marketing for Developers",
   "videos": [

--- a/djangocon-eu-2017/videos/navigating-unconscious-bias-by-anna-schneider.json
+++ b/djangocon-eu-2017/videos/navigating-unconscious-bias-by-anna-schneider.json
@@ -6,6 +6,7 @@
   "speakers": [
     "Anna Schneider"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/IBxIhgwSGJk/hqdefault.jpg",
   "title": "Navigating unconscious bias",
   "videos": [

--- a/djangocon-eu-2017/videos/planet-friendly-web-development-with-django-by-chris-adams.json
+++ b/djangocon-eu-2017/videos/planet-friendly-web-development-with-django-by-chris-adams.json
@@ -4,11 +4,15 @@
   "language": "eng",
   "recorded": "2017-04-04",
   "related_urls": [
-    "https://www.slideshare.net/mobile/chris.d.adams/djangocon-europe-2017-planet-friendly-django"
+    {
+      "label": "slides",
+      "url": "https://www.slideshare.net/mobile/chris.d.adams/djangocon-europe-2017-planet-friendly-django"
+    }
   ],
   "speakers": [
     "Chris Adams"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/wuCVqSN8nBM/hqdefault.jpg",
   "title": "Planet friendly web development with Django",
   "videos": [

--- a/djangocon-eu-2017/videos/qualities-of-great-reusable-django-apps-by-flavio-juvenal-da-silva-junior.json
+++ b/djangocon-eu-2017/videos/qualities-of-great-reusable-django-apps-by-flavio-juvenal-da-silva-junior.json
@@ -4,11 +4,15 @@
   "language": "eng",
   "recorded": "2017-04-03",
   "related_urls": [
-    "https://docs.google.com/presentation/d/15Jcf3HBko0qzE7HY411-4RjVDiCiPeEZlZbipTo7K50/edit?usp=sharing"
+    {
+      "label": "slides",
+      "url": "https://docs.google.com/presentation/d/15Jcf3HBko0qzE7HY411-4RjVDiCiPeEZlZbipTo7K50/edit?usp=sharing"
+    }
   ],
   "speakers": [
     "Flavio Juvenal da Silva Junior"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/AMg4Iind90Q/hqdefault.jpg",
   "title": "Qualities of great reusable Django apps",
   "videos": [

--- a/djangocon-eu-2017/videos/radio-free-django-building-a-radio-station-on-django-by-mark-steadman.json
+++ b/djangocon-eu-2017/videos/radio-free-django-building-a-radio-station-on-django-by-mark-steadman.json
@@ -4,11 +4,15 @@
   "language": "eng",
   "recorded": "2017-04-03",
   "related_urls": [
-    "https://www.slideshare.net/iamsteadman/radio-free-django"
+    {
+      "label": "slides",
+      "url": "https://www.slideshare.net/iamsteadman/radio-free-django"
+    }
   ],
   "speakers": [
     "Mark Steadman"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/paurfD95XbE/hqdefault.jpg",
   "title": "Radio Free Django - Building a radio station on Django",
   "videos": [

--- a/djangocon-eu-2017/videos/rants-and-ruminations-from-a-job-applicant-after-cs-job-interviews-in-silicon-valley-susan-tan.json
+++ b/djangocon-eu-2017/videos/rants-and-ruminations-from-a-job-applicant-after-cs-job-interviews-in-silicon-valley-susan-tan.json
@@ -4,11 +4,15 @@
   "language": "eng",
   "recorded": "2017-04-05",
   "related_urls": [
-    "https://www.slideshare.net/onceuponatimeforever/rants-and-ruminations-from-a-job-applicant-after-cs-job-interviews-in-silicon-valley-76151210"
+    {
+      "label": "slides",
+      "url": "https://www.slideshare.net/onceuponatimeforever/rants-and-ruminations-from-a-job-applicant-after-cs-job-interviews-in-silicon-valley-76151210"
+    }
   ],
   "speakers": [
     "Susan Tan"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/QGWAmGPpTXU/hqdefault.jpg",
   "title": "Rants and Ruminations From A Job Applicant After One Hundred! CS Job Interviews in Silicon Valley",
   "videos": [

--- a/djangocon-eu-2017/videos/serverlessness-augmenting-your-django-apps-with-functions-as-a-service-by-tom-dyson.json
+++ b/djangocon-eu-2017/videos/serverlessness-augmenting-your-django-apps-with-functions-as-a-service-by-tom-dyson.json
@@ -4,11 +4,15 @@
   "language": "eng",
   "recorded": "2017-04-03",
   "related_urls": [
-    "https://tom.s3.amazonaws.com/serverlessness-djangoconeu-2017.pdf"
+    {
+      "label": "slides",
+      "url": "https://tom.s3.amazonaws.com/serverlessness-djangoconeu-2017.pdf"
+    }
   ],
   "speakers": [
     "Tom Dyson"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/PpZfTTuTOvw/hqdefault.jpg",
   "title": "Serverlessness - augmenting your Django apps with Functions-as-a-Service",
   "videos": [

--- a/djangocon-eu-2017/videos/services-architecture-channels-by-andrew-godwin.json
+++ b/djangocon-eu-2017/videos/services-architecture-channels-by-andrew-godwin.json
@@ -4,11 +4,15 @@
   "language": "eng",
   "recorded": "2017-04-03",
   "related_urls": [
-    "https://speakerdeck.com/andrewgodwin/services-architecture-and-channels"
+    {
+      "label": "slides",
+      "url": "https://speakerdeck.com/andrewgodwin/services-architecture-and-channels"
+    }
   ],
   "speakers": [
     "Andrew Godwin"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/IwL-veifzyw/hqdefault.jpg",
   "title": "Services, Architecture & Channels",
   "videos": [

--- a/djangocon-eu-2017/videos/setting-up-a-python-community-in-zimbabwe-by-anna-makarudze-humphrey-butau.json
+++ b/djangocon-eu-2017/videos/setting-up-a-python-community-in-zimbabwe-by-anna-makarudze-humphrey-butau.json
@@ -4,12 +4,16 @@
   "language": "eng",
   "recorded": "2017-04-03",
   "related_urls": [
-    "https://speakerdeck.com/amakarudze/setting-up-a-python-community-in-zimbabwe-djangocon-europe-2017"
+    {
+      "label": "slides",
+      "url": "https://speakerdeck.com/amakarudze/setting-up-a-python-community-in-zimbabwe-djangocon-europe-2017"
+    }
   ],
   "speakers": [
     "Anna Makarudze",
     "Humphrey Butau"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/Y298EgZJMow/hqdefault.jpg",
   "title": "Setting up a Python Community in Zimbabwe",
   "videos": [

--- a/djangocon-eu-2017/videos/solidarity-of-systers-by-khushbu-parakh.json
+++ b/djangocon-eu-2017/videos/solidarity-of-systers-by-khushbu-parakh.json
@@ -4,11 +4,15 @@
   "language": "eng",
   "recorded": "2017-04-05",
   "related_urls": [
-    "https://speakerdeck.com/khushbuparakh/solidarity-of-systers"
+    {
+      "label": "slides",
+      "url": "https://speakerdeck.com/khushbuparakh/solidarity-of-systers"
+    }
   ],
   "speakers": [
     "Khushbu Parakh"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/RJRbcvv6UEM/hqdefault.jpg",
   "title": "Solidarity of Systers",
   "videos": [

--- a/djangocon-eu-2017/videos/staying-dryer-when-working-with-django-and-frontend-frameworkslibraries-by-emma-delescolle.json
+++ b/djangocon-eu-2017/videos/staying-dryer-when-working-with-django-and-frontend-frameworkslibraries-by-emma-delescolle.json
@@ -4,11 +4,15 @@
   "language": "eng",
   "recorded": "2017-04-03",
   "related_urls": [
-    "http://slides.com/emma_be/dryer-drf#/"
+    {
+      "label": "slides",
+      "url": "http://slides.com/emma_be/dryer-drf#/"
+    }
   ],
   "speakers": [
     "Emma Delescolle"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/4GTc_qwJz1E/hqdefault.jpg",
   "title": "Staying DRY(er) when working with Django and frontend frameworks/libraries",
   "videos": [

--- a/djangocon-eu-2017/videos/the-art-of-interacting-with-an-autistic-software-developer-by-sara-peeters.json
+++ b/djangocon-eu-2017/videos/the-art-of-interacting-with-an-autistic-software-developer-by-sara-peeters.json
@@ -4,11 +4,15 @@
   "language": "eng",
   "recorded": "2017-04-03",
   "related_urls": [
-    "https://speakerdeck.com/githubsara/the-art-of-interacting-with-an-autistic-software-developer"
+    {
+      "label": "slides",
+      "url": "https://speakerdeck.com/githubsara/the-art-of-interacting-with-an-autistic-software-developer"
+    }
   ],
   "speakers": [
     "Sara Peeters"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/oTuhqnWRt84/hqdefault.jpg",
   "title": "The art of interacting with an autistic software developer",
   "videos": [

--- a/djangocon-eu-2017/videos/the-ghost-in-the-algorithm-how-to-define-and-to-apply-digital-ethics-for-the-common-good.json
+++ b/djangocon-eu-2017/videos/the-ghost-in-the-algorithm-how-to-define-and-to-apply-digital-ethics-for-the-common-good.json
@@ -4,13 +4,17 @@
   "language": "eng",
   "recorded": "2017-04-05",
   "related_urls": [
-    "https://2017.djangocon.eu/media/filer_public/35/d3/35d33684-eeb4-46ea-92ea-6d104caf427c/ghost_in_the_algorithm_-_chiusi.pdf"
+    {
+      "label": "slides",
+      "url": "https://2017.djangocon.eu/media/filer_public/35/d3/35d33684-eeb4-46ea-92ea-6d104caf427c/ghost_in_the_algorithm_-_chiusi.pdf"
+    }
   ],
   "speakers": [
     "Fabio Chiusi"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/_aSyqQh6z0c/hqdefault.jpg",
-  "title": "\"The ghost in the algorithm: how to define and to apply digital ethics for the common good\"",
+  "title": "The ghost in the algorithm: how to define and to apply digital ethics for the common good",
   "videos": [
     {
       "type": "youtube",

--- a/djangocon-eu-2017/videos/the-openholter-project-diy-cardiometry-with-arduino-and-django-by-roberto-rosario.json
+++ b/djangocon-eu-2017/videos/the-openholter-project-diy-cardiometry-with-arduino-and-django-by-roberto-rosario.json
@@ -4,11 +4,15 @@
   "language": "eng",
   "recorded": "2017-04-04",
   "related_urls": [
-    "https://speakerdeck.com/siloraptor/openholter-project-d-dot-i-y-electrocardiography-using-arduino-and-django"
+    {
+      "label": "slides",
+      "url": "https://speakerdeck.com/siloraptor/openholter-project-d-dot-i-y-electrocardiography-using-arduino-and-django"
+    }
   ],
   "speakers": [
     "Roberto Rosario"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/rubzEAojf-k/hqdefault.jpg",
   "title": "The OpenHolter project: DIY Cardiometry with Arduino and Django.",
   "videos": [

--- a/djangocon-eu-2017/videos/the-road-to-unempathic-communities-is-paved-with-good-intentions-by-erik-romijn.json
+++ b/djangocon-eu-2017/videos/the-road-to-unempathic-communities-is-paved-with-good-intentions-by-erik-romijn.json
@@ -6,6 +6,7 @@
   "speakers": [
     "Erik Romijn"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/PuLi3Uegn9g/hqdefault.jpg",
   "title": "The road to unempathic communities is paved with good intentions",
   "videos": [

--- a/djangocon-eu-2017/videos/the-struggle-of-tech-feeling-better-as-a-learner-by-gloria-dwomoh.json
+++ b/djangocon-eu-2017/videos/the-struggle-of-tech-feeling-better-as-a-learner-by-gloria-dwomoh.json
@@ -4,13 +4,17 @@
   "language": "eng",
   "recorded": "2017-04-03",
   "related_urls": [
-    "https://github.com/blossomica/Presentations/blob/master/TheStruggleOfTech.pdf"
+    {
+      "label": "slides",
+      "url": "https://github.com/blossomica/Presentations/blob/master/TheStruggleOfTech.pdf"
+    }
   ],
   "speakers": [
     "Gloria Dwomoh"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/_KvJ2fHnSCM/hqdefault.jpg",
-  "title": "\"The Struggle of Tech: Feeling Better as a Learner\" by ",
+  "title": "The Struggle of Tech: Feeling Better as a Learner",
   "videos": [
     {
       "type": "youtube",

--- a/djangocon-eu-2017/videos/to-index-or-not-thats-not-the-question-by-markus-holtermann.json
+++ b/djangocon-eu-2017/videos/to-index-or-not-thats-not-the-question-by-markus-holtermann.json
@@ -4,11 +4,15 @@
   "language": "eng",
   "recorded": "2017-04-04",
   "related_urls": [
-    "https://speakerdeck.com/markush/to-index-or-not-thats-not-the-question-djangocon-europe-2017"
+    {
+      "label": "slides",
+      "url": "https://speakerdeck.com/markush/to-index-or-not-thats-not-the-question-djangocon-europe-2017"
+    }
   ],
   "speakers": [
     "Markus Holtermann"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/XCVzb5iCe_0/hqdefault.jpg",
   "title": "To Index or Not, That's Not The Question",
   "videos": [

--- a/djangocon-eu-2017/videos/understanding-the-amazing-world-behind-your-orm-by-louise-grandjonc.json
+++ b/djangocon-eu-2017/videos/understanding-the-amazing-world-behind-your-orm-by-louise-grandjonc.json
@@ -1,14 +1,18 @@
 {
-  "description": "Every django developer has used the ORM. It's terribly useful. Suddenly creating, retrieving, updating objects becomes easy without having to use the barbaric language that SQL can be. \nBut sometimes, out of nowhere, your API or view becomes really slow because of some magical thing happening behind your ORM. \nThe idea of this talk is to make a journey from the ORM to the database. I will hand out different tools to debug, understand what queries are executed and when. And once you have the queries, how to optimize it? How does the database execute the queries? How to optimize your number of queries, and the execution of these?\n\nThe talk will be explained with a same example developed along the theory to understand the application better. I will give a few examples of the problems that any developer will encounter. Then explain how to identify the problem : is it possible to lower the number of queries? If not, how can I know why a specific query is slow ?\n\nThe idea is that at the end of the conference, the developer can easily access the database log, identify the view queries and understand the big lines of an EXPLAIN in the database. Not necessarily in detail, but to be able to answer: is my query making a lot of loops through many tables? Is it using an index? Am I missing an index? And what is an index by the way?",
+  "description": "Every django developer has used the ORM. It's terribly useful. Suddenly creating, retrieving, updating objects becomes easy without having to use the barbaric language that SQL can be.\nBut sometimes, out of nowhere, your API or view becomes really slow because of some magical thing happening behind your ORM.\nThe idea of this talk is to make a journey from the ORM to the database. I will hand out different tools to debug, understand what queries are executed and when. And once you have the queries, how to optimize it? How does the database execute the queries? How to optimize your number of queries, and the execution of these?\n\nThe talk will be explained with a same example developed along the theory to understand the application better. I will give a few examples of the problems that any developer will encounter. Then explain how to identify the problem : is it possible to lower the number of queries? If not, how can I know why a specific query is slow ?\n\nThe idea is that at the end of the conference, the developer can easily access the database log, identify the view queries and understand the big lines of an EXPLAIN in the database. Not necessarily in detail, but to be able to answer: is my query making a lot of loops through many tables? Is it using an index? Am I missing an index? And what is an index by the way?",
   "duration": 1713,
   "language": "eng",
   "recorded": "2017-04-04",
   "related_urls": [
-    "https://fr.slideshare.net/LouiseGrandjonc/the-amazing-world-behind-your-orm"
+    {
+      "label": "slides",
+      "url": "https://fr.slideshare.net/LouiseGrandjonc/the-amazing-world-behind-your-orm"
+    }
   ],
   "speakers": [
     "Louise Grandjonc"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/Ph2hXpTW-Zg/hqdefault.jpg",
   "title": "Understanding the amazing world behind your ORM",
   "videos": [

--- a/djangocon-eu-2017/videos/using-type-checking-in-django-projects-with-mypy-by-daniel-moisset.json
+++ b/djangocon-eu-2017/videos/using-type-checking-in-django-projects-with-mypy-by-daniel-moisset.json
@@ -6,6 +6,7 @@
   "speakers": [
     "Daniel Moisset"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/vY0sSS0zN70/hqdefault.jpg",
   "title": "Using type checking in Django projects with mypy",
   "videos": [

--- a/djangocon-eu-2017/videos/weird-and-wonderful-things-to-do-with-the-orm-by-marc-tamlyn.json
+++ b/djangocon-eu-2017/videos/weird-and-wonderful-things-to-do-with-the-orm-by-marc-tamlyn.json
@@ -4,11 +4,15 @@
   "language": "eng",
   "recorded": "2017-04-05",
   "related_urls": [
-    "https://speakerdeck.com/mjtamlyn/weird-and-wonderful-things-to-do-with-the-orm"
+    {
+      "label": "slides",
+      "url": "https://speakerdeck.com/mjtamlyn/weird-and-wonderful-things-to-do-with-the-orm"
+    }
   ],
   "speakers": [
     "Marc Tamlyn"
   ],
+  "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/aDt4gu99_bE/hqdefault.jpg",
   "title": "Weird and Wonderful things to do with the ORM",
   "videos": [


### PR DESCRIPTION
Fix #247 
DjangoCon Europe 2017 is solved in #345, but reviewing it wanted to:
- Add empty tags to ease tag contributions
- Upgrade url format with label and URL
- Erase empty description in category.json
- Other minor twaks

Allow edits from maintainers wasn't activated, this PR makes the trick.