### PR TITLE
Montréal-Python 68: Adds vidéos of the talks

### DIFF
--- a/montreal-python/videos/mp68-the-talk-would-be-about-rasa-an-open-source-chatbots-platform.json
+++ b/montreal-python/videos/mp68-the-talk-would-be-about-rasa-an-open-source-chatbots-platform.json
@@ -1,0 +1,26 @@
+{
+  "description": "Most chatbots rely on external APIs for the cool stuff such as natural language understanding (NLU) and disappoint because if and else conditionals fail at delivering good representations of our non linear human way to converse. Wouldn\u2019t it be great if we could 1) take control of NLU and tweak it to better fit our needs and 2) really apply machine learning, extract patterns from real conversations, and handle dialogue in a decent manner? Well, we can, thanks to Rasa.ai. It\u2019s open-source, it\u2019s in Python, and it works.\n\nMontr\u00e9al-Python 68: Wysiwyg Xylophone \nhttps://montrealpython.org/2017/11/mp68/",
+  "recorded": "2017-11-20",
+  "language": "eng",
+  "related_urls": [
+    {
+      "label": "group web",
+      "url": "https://montrealpython.org"
+    },
+    {
+      "label": "MP68",
+      "url": "http://montrealpython.org/en/2017/11/mp68/"
+    }
+  ],
+  "speakers": [
+    "Nathan Zylbersztejn"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/0hZay4KSLFw/hqdefault.jpg",
+  "title": "The talk would be about Rasa, an open-source chatbots platform",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=0hZay4KSLFw"
+    }
+  ]
+}

--- a/montreal-python/videos/mp68-va-debugger-ton-python.json
+++ b/montreal-python/videos/mp68-va-debugger-ton-python.json
@@ -1,0 +1,27 @@
+{
+  "copyright_text": "Creative Commons Attribution license (reuse allowed)",
+  "description": "Cette pr\u00e9sentation vous explique les bases de Pdb ainsi que GDB, afin de debugger plus facilement vos scripts Python.\n\nMontr\u00e9al-Python 68: Wysiwyg Xylophone \nhttps://montrealpython.org/2017/11/mp68/",
+  "recorded": "2017-11-20",
+  "language": "fra",
+  "related_urls": [
+    {
+      "label": "group web",
+      "url": "https://montrealpython.org"
+    },
+    {
+      "label": "MP68",
+      "url": "http://montrealpython.org/en/2017/11/mp68/"
+    }
+  ],
+  "speakers": [
+    "Stéphane Wirtel"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/cb_cNEIIb-4/hqdefault.jpg",
+  "title": "Va debugger ton Python!",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=cb_cNEIIb-4"
+    }
+  ]
+}

--- a/montreal-python/videos/mp68-writing-a-python-interpreter-in-python-from-scratch.json
+++ b/montreal-python/videos/mp68-writing-a-python-interpreter-in-python-from-scratch.json
@@ -1,0 +1,26 @@
+{
+  "description": "I will show a prototype of a Python interpreter written in entirely in Python itself (that isn't Pypy).\n\nThe goal is to have simpler internals to allow experimenting with changes to the language more easily. This interpreter has a small core with much of the library modifiable at run time for quickly testing changes. This differs from Pypy that aimed for full Python compatibility and speed (from JIT compilation). I will show some of the interesting things that you can do with this interpreter.\n\nThis interpreter has two parts: a parser to transform source to Abstract Syntax Tree and a runner for traversing this tree. I will give an overview of how both part work and discuss some challenges encountered and their solution.\n\nThis interpreter makes use of very few libraries, and only those included with CPython.\n\nThis project is looking for members to discuss ways of simplifying parts of the interpreter (among other things).\n\nMontr\u00e9al-Python 68: Wysiwyg Xylophone \nhttps://montrealpython.org/2017/11/mp68/",
+  "recorded": "2017-11-20",
+  "language": "eng",
+  "related_urls": [
+    {
+      "label": "group web",
+      "url": "https://montrealpython.org"
+    },
+    {
+      "label": "MP68",
+      "url": "http://montrealpython.org/en/2017/11/mp68/"
+    }
+  ],
+  "speakers": [
+    "Zhentao Li"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/dCCcDj8YtDI/hqdefault.jpg",
+  "title": "Writing a Python interpreter in Python from scratch",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=dCCcDj8YtDI"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the videos of the talks for our latest event mp68 http://montrealpython.org/en/2017/11/mp68/