### PR TITLE
Adds the videos of the Montreal-Python 67 event

### DIFF
--- a/montreal-python/videos/mp67-10-points-pour-comprendre-les-containers.json
+++ b/montreal-python/videos/mp67-10-points-pour-comprendre-les-containers.json
@@ -1,0 +1,26 @@
+{
+  "description": "Qu'est-ce qu'un container? Une image? Peut-on rouler plusieurs programmes dans un seul container? Peut-on utiliser Docker directement ou faut-il un orchestrateur comme Kubernetes? Avec dix questions en dix minutes, vous aurez une bonne compr\u00e9hension des d\u00e9finitions et des r\u00f4les de ces objets, et pourrez mieux appr\u00e9cier les pr\u00e9sentations plus avanc\u00e9es sur le sujet.\n\nMontr\u00e9al-Python 67: Ultramodern Vintage - PyCon Canada Special\nhttps://montrealpython.org/2017/10/mp67/",
+  "recorded": "2017-10-30",
+  "language": "fra",
+  "related_urls": [
+    {
+      "label": "group web",
+      "url": "https://montrealpython.org"
+    },
+    {
+      "label": "MP67",
+      "url": "http://montrealpython.org/en/2017/10/mp67/"
+    }
+  ],
+  "speakers": [
+    "\u00c9ric Araujo"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/oUOe6E2YTPE/hqdefault.jpg",
+  "title": "10 points pour comprendre les containers",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=oUOe6E2YTPE"
+    }
+  ]
+}

--- a/montreal-python/videos/mp67-domo-arigato-mr-roboto-calibrating-robots-with-python.json
+++ b/montreal-python/videos/mp67-domo-arigato-mr-roboto-calibrating-robots-with-python.json
@@ -1,0 +1,26 @@
+{
+  "description": "Modern robotic applications often rely on offline programming to reduce process downtime. In a virtual environment, robot application specialists may program, visualize, and test their robotic application before uploading it to the real production environment, saving time and costs. However, to achieve a high level of fidelity between virtual and production environments, the robot system must be accurate.\n\nUnfortunately, even though most industrial robots are inherently precise (i.e., repeatable), they are not necessarily very accurate. One cost-effective approach to obtaining a more accurate robot is through calibration, where the actual kinematic and non-kinematic parameters of the robot model are identified and improved upon when compared to the nominal model. This talk introduces pybotics, an open-source Python toolbox for robot kinematics and calibration\n\nMontr\u00e9al-Python 67: Ultramodern Vintage - PyCon Canada Special\nhttps://montrealpython.org/2017/10/mp67/",
+  "recorded": "2017-10-30",
+  "language": "eng",
+  "related_urls": [
+    {
+      "label": "group web",
+      "url": "https://montrealpython.org"
+    },
+    {
+      "label": "MP67",
+      "url": "http://montrealpython.org/en/2017/10/mp67/"
+    }
+  ],
+  "speakers": [
+    "Nicholas Nadeau"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/wgKoGA69YXQ/hqdefault.jpg",
+  "title": "Domo arigato, Mr. Roboto: calibrating robots with Python",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=wgKoGA69YXQ"
+    }
+  ]
+}

--- a/montreal-python/videos/mp67-multiprocessing-how-to-run-blockly-generated-code-in-python.json
+++ b/montreal-python/videos/mp67-multiprocessing-how-to-run-blockly-generated-code-in-python.json
@@ -1,0 +1,26 @@
+{
+  "description": "Blockly is a front-end GUI developed by Google that allows developers to create a drag-and-drop language for their product. However Blockly only generates a string and does not run code directly. I will take a look at the various potential approaches to execute code that is in a string: exec - quick for short commands subprocess - can be interrupted * multiprocessing - can pass data back and forth by using queues The talk is mainly about launching processes, dealing with zombies, interrupting processes based on user input and passing data back and forth between processes. Brief mentions of Flask are to be expected. Examples will be based on my experience in developing Bloxter a graphical drag-and-drop language for the GoPiGo3 to be used at home or in classrooms.\n\nMontr\u00e9al-Python 67: Ultramodern Vintage - PyCon Canada Special\nhttps://montrealpython.org/2017/10/mp67/",
+  "recorded": "2017-10-30",
+  "language": "eng",
+  "related_urls": [
+    {
+      "label": "group web",
+      "url": "https://montrealpython.org"
+    },
+    {
+      "label": "MP67",
+      "url": "http://montrealpython.org/en/2017/10/mp67/"
+    }
+  ],
+  "speakers": [
+    "Nicole Parrot"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/l5lc0nHD98E/hqdefault.jpg",
+  "title": "Multiprocessing: how to run Blockly generated code in Python",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=l5lc0nHD98E"
+    }
+  ]
+}

--- a/montreal-python/videos/mp67-so-you-want-to-be-a-wizard.json
+++ b/montreal-python/videos/mp67-so-you-want-to-be-a-wizard.json
@@ -1,0 +1,26 @@
+{
+  "description": "I don't always feel like a wizard. I'm not the most experienced member on my team, like most people I sometimes find my work difficult, and I still have a TON TO LEARN.\n\nBut along the way, I have learned a few ways to debug tricky problems, get the information I need from my colleagues, and get my job done. \n\nMontr\u00e9al-Python 67: Ultramodern Vintage - PyCon Canada Special\nhttps://montrealpython.org/2017/10/mp67/",
+  "recorded": "2017-10-30",
+  "language": "eng",
+  "related_urls": [
+    {
+      "label": "group web",
+      "url": "https://montrealpython.org"
+    },
+    {
+      "label": "MP67",
+      "url": "http://montrealpython.org/en/2017/10/mp67/"
+    }
+  ],
+  "speakers": [
+    "Julia Evans"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/zUihajla2SE/hqdefault.jpg",
+  "title": "So you want to be a wizard",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=zUihajla2SE"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the videos of http://montrealpython.org/en/2017/10/mp67,

Since those talks were in preparation of https://2017.pycon.ca/, we were waiting the conference was done before posting them online.