### PR TITLE
corrected "tutorial repository" url

### DIFF
--- a/scipy-2017/videos/interactive-data-visualization-with-holoviews-bokeh-scipy-2017-tutorial-jean-luc-stevens-bry.json
+++ b/scipy-2017/videos/interactive-data-visualization-with-holoviews-bokeh-scipy-2017-tutorial-jean-luc-stevens-bry.json
@@ -11,7 +11,7 @@
     },
     {
       "label": "tutorial repository",
-      "url": "https://scipy2017.scipy.org/ehome/220975/493422/"
+      "url": "https://github.com/ioam/scipy-2017-holoviews-tutorial"
     }
   ],
   "speakers": [


### PR DESCRIPTION
Changed "tutorial repository" url to point to the GitHub repo, rather than the SciPy schedule page.