### PR TITLE
Fix date checking in json schema

### DIFF
--- a/.schemas/video.json
+++ b/.schemas/video.json
@@ -1,5 +1,5 @@
 {
-  "$schema":"http://json-schema.org/draft-04/schema#",
+  "$schema":"http://json-schema.org/draft-07/schema#",
   "description":"The schema for a video record in pyvideo/data",
   "properties":{
     "alias":{
@@ -35,9 +35,13 @@
       "anyOf": [{"type": "null"}, {"type": "string"}]
     },
     "recorded":{
-      "description":"ISO 8601 Date on which video was recorded (YYYY-MM-DD)",
-      "anyOf": [{"type": "null"}, {"type": "string"}],
-      "format":"date-time"
+      "description":"ISO 8601 Date on which video was recorded (YYYY-MM-DD[Thh:mm[+hh:mm]])",
+      "anyOf": [
+        {"type": "null"},
+        {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}([+-][0-9]{2}:[0-9]{2})?)?$"
+        }]
     },
     "related_urls":{
       "description":"Array of related resources' URLs.",

--- a/.tests/schemas.py
+++ b/.tests/schemas.py
@@ -31,7 +31,10 @@ def check_schemas(data_root, schemas_dir, verbose=False):
                     error_count += 1
                     continue
                 try:
-                    jsonschema.validate(blob, schema_blob)
+                    jsonschema.validate(
+                        blob,
+                        schema_blob,
+                        format_checker=jsonschema.FormatChecker())
                 except jsonschema.exceptions.ValidationError as e:
                     print(file_path, flush=True)
                     if verbose:


### PR DESCRIPTION
Fixes #472

Used a pattern because I tried, but failed, to solve the bug with:
~~~ json
    "recorded":{
      "description":"ISO 8601 Date on which video was recorded (YYYY-MM-DD[Thh:mm[+hh:mm]])",
      "anyOf": [
        {"type": "null"},
        {
          "type": "string",
          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$"
        }, {
          "type": "string",
          "format":"date"
        }, {
          "type": "string",
          "format":"date-time"
        }]
    },
~~~
Failed because the date `2016-4-28` don't break the test. (Maybe a bug in pip package `strict-rfc3339` ?)