### PR TITLE
Script to ease timetable creation in lightning talks

### DIFF
--- a/tools/csv2rst.py
+++ b/tools/csv2rst.py
@@ -9,8 +9,7 @@ import json
 import logging
 import os.path
 import sys
-sys.path.insert(0, '.')
-from tools.constants import JSON_FORMAT_KWARGS
+from constants import JSON_FORMAT_KWARGS
 
 
 def create_sample_csv(filename):

--- a/tools/csv2rst.py
+++ b/tools/csv2rst.py
@@ -1,8 +1,19 @@
 #!/usr/bin/env python3
 # coding: utf-8
 """
-Translates a lightning talk description from csv to ReStructuredText
+Prints a table of contents for a lightning talks description field.
+
+Translates a lightning talk timetable from csv timetable to a table of contents
+in ReStructuredText format, for use in the description field. The input csv
+should be in the following format:
+
+  Time,Speaker,Title
+  00:00,Albus Dumbledore,"Not who, but how?"
+  06:25,Hermione Granger,Fear of a name only increases fear of the thing itself
+  11:51,Lord Voldemort,Avada Kedavra
+  ...
 """
+
 import argparse
 import csv
 import json
@@ -70,8 +81,7 @@ def add_description(json_file, description):
 def main():
     """Translates a lightning talk description from csv to ReStructuredText"""
     parser = argparse.ArgumentParser(
-        description=
-        'Create a lightning talk description field from a csv timetable.')
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument(
         "csv", default='lightning.csv', help="path to csv file", type=str)
     parser.add_argument("video_url", help="youtube video url", type=str)

--- a/tools/csv2rst.py
+++ b/tools/csv2rst.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# coding: utf-8
+"""
+Translates a lightning talk description from csv to ReStructuredText
+"""
+import argparse
+import csv
+import json
+import logging
+import os.path
+import sys
+sys.path.insert(0, '.')
+from tools.constants import JSON_FORMAT_KWARGS
+
+
+def create_sample_csv(filename):
+    """Create sample file as base of the lightning talk table"""
+    table = [['Time', 'Speaker', 'Title'], ['00:00', 'Unknown', 'Unknown']]
+
+    with open(filename, 'w', newline='') as csvfile:
+        lightning_writer = csv.writer(csvfile)
+        for line in table:
+            lightning_writer.writerow(line)
+
+
+def csv_description_to_rst(filename, url):
+    """Prints a ReStructuredText list-table in json, in the description value
+    """
+
+    def body_line(time, speaker, title, first_line=False):
+        """Prints a row of ReStructuredText list-table"""
+        if first_line:
+            hiperlink_underscore = ''
+        else:
+            hiperlink_underscore = '_'
+        return ("   * - {}{}\n"
+                "     - {}\n"
+                "     - {}\n").format(time, hiperlink_underscore, speaker,
+                                      title)
+
+    head = (".. list-table:: Lightning Talks\n"
+            "   :widths: 10 30 60\n"
+            "   :header-rows: 1\n\n")
+    body = "\n" + body_line('Time', 'Speaker', 'Title', first_line=True)
+    footer = "\n\n"
+    if '?' in url:
+        url_argument_operator = '&'
+    else:
+        url_argument_operator = '?'
+    with open(filename, newline='') as csvfile:
+        lightning_reader = csv.DictReader(csvfile)
+        for row in lightning_reader:
+            body += body_line(row['Time'], row['Speaker'], row['Title'])
+            minutes, seconds = row['Time'].split(':')
+            footer += ".. _{}: {}{}t={}m{}s\n".format(
+                row['Time'], url, url_argument_operator, minutes, seconds)
+    return head + body + footer
+
+
+def add_description(json_file, description):
+    """Read json file and add description value"""
+    try:
+        data = json.load(json_file)
+    except ValueError:
+        logging.error('Json syntax error in file %s', json_file.name)
+        raise
+    data['description'] = description
+    return data
+
+
+def main():
+    """Translates a lightning talk description from csv to ReStructuredText"""
+    parser = argparse.ArgumentParser(
+        description=
+        'Create a lightning talk description field from a csv timetable.')
+    parser.add_argument(
+        "csv", default='lightning.csv', help="path to csv file", type=str)
+    parser.add_argument("video_url", help="youtube video url", type=str)
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="show debug messages")
+    parser.add_argument(
+        "-n",
+        "--new_csv",
+        action="store_true",
+        help="create new csv empty file skeleton")
+    parser.add_argument(
+        "-j",
+        "--json",
+        nargs='?',
+        type=argparse.FileType('r'),
+        help="Read json file and replace description with csv data")
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+        logging.debug('Arguments: %s', args)
+    else:
+        logging.basicConfig(level=logging.WARNING)
+    json_output = args.json
+    csv_path = args.csv
+    video_url = args.video_url
+    if args.new_csv:
+        if os.path.exists(csv_path):
+            raise Exception(
+                'Error creating new file. File exists: {}'.format(csv_path))
+        else:
+            create_sample_csv(csv_path)
+    description = csv_description_to_rst(csv_path, video_url)
+    json_file = args.json
+    if json_output:
+        print(
+            json.dumps(
+                add_description(json_file, description), **JSON_FORMAT_KWARGS))
+    else:
+        print(description)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This script creates a lightning talk description field from a csv timetable.

The result is (in the description) something like:


Time | Speaker | Title
--- | --- | ---
[0:19](https://www.youtube.com/watch?v=bJmx0tcVubY&t=0m19s) | Sam Kitajima-Kimbrel |You Aren't Facebook, and That's OK
[4:55](https://www.youtube.com/watch?v=bJmx0tcVubY&t=4m55s) | Jason King | Don't do what I did
[9:55](https://www.youtube.com/watch?v=bJmx0tcVubY&t=9m55s) | Evan Kohilas | Rubber Snaek
... | ... | ...