### PR TITLE
Remove event info and speaker from title field (Djangocong Montpellier 2012)

### DIFF
--- a/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-bruno-renie-packager-son-projet-django.json
+++ b/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-bruno-renie-packager-son-projet-django.json
@@ -10,7 +10,7 @@
     "Bruno Reni\u00e9"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/jd4dN5QkjNU/hqdefault.jpg",
-  "title": "Djangocong 14-15 Avril 2012 / Bruno Reni\u00e9 - Packager son projet Django",
+  "title": "Packager son projet Django",
   "videos": [
     {
       "type": "youtube",

--- a/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-bruno-renie-staticfiles-tout-ce-quil-faut-savoir.json
+++ b/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-bruno-renie-staticfiles-tout-ce-quil-faut-savoir.json
@@ -10,7 +10,7 @@
     "Bruno Reni\u00e9"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/ufTuf25eQYo/hqdefault.jpg",
-  "title": "Djangocong 14-15 Avril 2012 / Bruno Reni\u00e9 - Staticfiles: tout ce qu'il faut savoir...",
+  "title": "Staticfiles: tout ce qu'il faut savoir...",
   "videos": [
     {
       "type": "youtube",

--- a/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-craig-kertiens-moving-from-django-apps-to-services-en-anglais.json
+++ b/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-craig-kertiens-moving-from-django-apps-to-services-en-anglais.json
@@ -10,7 +10,7 @@
     "Craig Kertiens"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/ztGpK-v2Oow/hqdefault.jpg",
-  "title": "Djangocong 14-15 Avril 2012 / Craig Kertiens - Moving from Django Apps to Services (en Anglais)",
+  "title": "Moving from Django Apps to Services (en Anglais)",
   "videos": [
     {
       "type": "youtube",

--- a/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-david-larlet-communautes-ouvertes.json
+++ b/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-david-larlet-communautes-ouvertes.json
@@ -10,7 +10,7 @@
     "David Larlet"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/tpose7DM2aA/hqdefault.jpg",
-  "title": "Djangocong 14-15 Avril 2012 / David Larlet - Communaut\u00e9s ouvertes",
+  "title": "Communaut\u00e9s ouvertes",
   "videos": [
     {
       "type": "youtube",

--- a/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-dominique-guardiola-linked-data-avec-django.json
+++ b/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-dominique-guardiola-linked-data-avec-django.json
@@ -10,7 +10,7 @@
     "Dominique Guardiola"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/Zyw9HESJYjY/hqdefault.jpg",
-  "title": "Djangocong 14-15 Avril 2012 / Dominique Guardiola - Linked Data avec Django",
+  "title": "Linked Data avec Django",
   "videos": [
     {
       "type": "youtube",

--- a/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-marc-hertzog-its-over-9000.json
+++ b/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-marc-hertzog-its-over-9000.json
@@ -13,7 +13,7 @@
     "lightning talks"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/j950wKxfwSE/hqdefault.jpg",
-  "title": "Djangocong 14-15 Avril 2012 / Marc Hertzog - It's over 9000",
+  "title": "It's over 9000",
   "videos": [
     {
       "type": "youtube",

--- a/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-martin-de-wulf-taches-backend-avec-celery.json
+++ b/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-martin-de-wulf-taches-backend-avec-celery.json
@@ -10,7 +10,7 @@
     "Martin De Wulf"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/Z2KHeORO2tU/hqdefault.jpg",
-  "title": "Djangocong 14-15 Avril 2012 / Martin De Wulf - T\u00e2ches backend avec Celery",
+  "title": "T\u00e2ches backend avec Celery",
   "videos": [
     {
       "type": "youtube",

--- a/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-mathieu-agopian-le-miroir-pypi-local-du-pauvre.json
+++ b/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-mathieu-agopian-le-miroir-pypi-local-du-pauvre.json
@@ -10,7 +10,7 @@
     "Mathieu Agopian"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/_bIfEkyME6k/hqdefault.jpg",
-  "title": "Djangocong 14-15 Avril 2012 / Mathieu Agopian - Le miroir Pypi local du pauvre",
+  "title": "Le miroir Pypi local du pauvre",
   "videos": [
     {
       "type": "youtube",

--- a/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-mathieu-pillard-dans-lenfer-de-la-bascule.json
+++ b/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-mathieu-pillard-dans-lenfer-de-la-bascule.json
@@ -10,7 +10,7 @@
     "Mathieu Pillard"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/by4Cz88Mkgg/hqdefault.jpg",
-  "title": "Djangocong 14-15 Avril 2012 / Mathieu Pillard - Dans l'enfer de la bascule",
+  "title": "Dans l'enfer de la bascule",
   "videos": [
     {
       "type": "youtube",

--- a/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-raphael-barrois-gerer-un-workflow-avec-xworkflows.json
+++ b/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-raphael-barrois-gerer-un-workflow-avec-xworkflows.json
@@ -6,9 +6,11 @@
     "http://rencontres.django-fr.org/2012/lightning-talks.html#l2",
     "http://rencontres.django-fr.org/2012/presentations/xworkflows/"
   ],
-  "speakers": [],
+  "speakers": [
+    "Rapha\u00ebl Barrois"
+  ],
   "thumbnail_url": "https://i.ytimg.com/vi/7lqKTs00ojs/hqdefault.jpg",
-  "title": "Djangocong 14-15 Avril 2012 /  Rapha\u00ebl Barrois - G\u00e9rer un workflow avec xworkflows",
+  "title": "G\u00e9rer un workflow avec xworkflows",
   "videos": [
     {
       "type": "youtube",

--- a/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-souen-boniface-admin-django-aller-plus-loin-aller-plus-haut.json
+++ b/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-souen-boniface-admin-django-aller-plus-loin-aller-plus-haut.json
@@ -10,7 +10,7 @@
     "Souen Boniface"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/IvENCRlxchM/hqdefault.jpg",
-  "title": "Djangocong 14-15 Avril 2012 / Souen Boniface - Admin django: aller plus loin, aller plus haut",
+  "title": "Admin django: aller plus loin, aller plus haut",
   "videos": [
     {
       "type": "youtube",

--- a/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-stephane-angel-django-advanced-cache-templatetag.json
+++ b/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-stephane-angel-django-advanced-cache-templatetag.json
@@ -13,7 +13,7 @@
     "lightning talks"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/riG6Myp28YI/hqdefault.jpg",
-  "title": "Djangocong 14-15 Avril 2012 / St\u00e9phane Angel - Django advanced cache templatetag",
+  "title": "Django advanced cache templatetag",
   "videos": [
     {
       "type": "youtube",

--- a/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-stephane-angel-retour-sur-dvpt-site-a-gros-volume-de-donnees.json
+++ b/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-stephane-angel-retour-sur-dvpt-site-a-gros-volume-de-donnees.json
@@ -10,7 +10,7 @@
     "St\u00e9phane Angel"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/fv_VPVaU9YY/hqdefault.jpg",
-  "title": "Djangocong 14-15 Avril 2012 / St\u00e9phane Angel - Retour sur dvpt.. site \u00e0 gros volume de donn\u00e9es",
+  "title": "Retour sur dvpt.. site \u00e0 gros volume de donn\u00e9es",
   "videos": [
     {
       "type": "youtube",

--- a/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-stephane-raimbault-presentation-de-larchitecture-autolib.json
+++ b/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-stephane-raimbault-presentation-de-larchitecture-autolib.json
@@ -10,7 +10,7 @@
     "Stephane Raimbault"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/gcP-jMt3gGQ/hqdefault.jpg",
-  "title": "Djangocong 14-15 Avril 2012 / Stephane Raimbault - Pr\u00e9sentation de l'architecture Autolib'",
+  "title": "Pr\u00e9sentation de l'architecture Autolib'",
   "videos": [
     {
       "type": "youtube",

--- a/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-stephane-raimbault-raconter-vos-tests-en-histoire-avec-lettuce.json
+++ b/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-stephane-raimbault-raconter-vos-tests-en-histoire-avec-lettuce.json
@@ -13,7 +13,7 @@
     "lightning talks"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/-xOjDvifp6k/hqdefault.jpg",
-  "title": "Djangocong 14-15 Avril 2012 / Stephane Raimbault - Raconter vos tests en histoire avec Lettuce",
+  "title": "Raconter vos tests en histoire avec Lettuce",
   "videos": [
     {
       "type": "youtube",

--- a/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-timothee-peignier-un-site-web-mobile-en-django.json
+++ b/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-timothee-peignier-un-site-web-mobile-en-django.json
@@ -10,7 +10,7 @@
     "Timothee Peignier"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/2HCs-6y8_HY/hqdefault.jpg",
-  "title": "Djangocong 14-15 Avril 2012 / Timothee Peignier - Un site web mobile en Django",
+  "title": "Un site web mobile en Django",
   "videos": [
     {
       "type": "youtube",

--- a/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-xavier-ordoquy-garder-un-oeil-sur-django-et-python.json
+++ b/djangocong-montpellier-2012/videos/djangocong-14-15-avril-2012-xavier-ordoquy-garder-un-oeil-sur-django-et-python.json
@@ -10,7 +10,7 @@
     "Xavier Ordoquy"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/BwLSHeOl7gM/hqdefault.jpg",
-  "title": "Djangocong 14-15 Avril 2012 / Xavier Ordoquy - Garder un oeil sur Django et Python",
+  "title": "Garder un oeil sur Django et Python",
   "videos": [
     {
       "type": "youtube",


### PR DESCRIPTION
This PR is a minor data cleanup that removes the event name, event date, and speaker name from the `title` field for all talks in the `djangocong-montpellier-2012` folder. 

For reference, `CONTRIBUTING.rst` says:

> Since the list of speakers, event name, and other metadata are captured elsewhere in each video's JSON object, it is suggested that the value of the title string contain only the title of the video and not contain any other information about the video.

