### PR TITLE
Add lang to base template from youtube scraper.

### DIFF
--- a/tools/youtube.py
+++ b/tools/youtube.py
@@ -98,6 +98,7 @@ BASE_VIDEO_BLOB = {
     'title': '',
     'recorded': '',
     'videos': [],
+    'language': '',
 }
 
 


### PR DESCRIPTION
Following up on comment from #213  - adding language to template here. It doesn't seem like `language` is in the response from YouTube, but adding the blank field to all new files created by the scraper seems like it might be a good reminder to fill that value out when creating or enhancing talk metadata.