### PR TITLE
Normalize 'Dr. Russell Keith-Magee' to 'Russell Keith-Magee'.

### DIFF
--- a/djangocon-2008/videos/djangocon-2008-panel-schema-evolution.json
+++ b/djangocon-2008/videos/djangocon-2008-panel-schema-evolution.json
@@ -5,7 +5,7 @@
   "speakers": [
     "Michael Trier",
     "Simon Willison",
-    "Dr. Russell Keith-Magee",
+    "Russell Keith-Magee",
     "Andrew Godwin"
   ],
   "tags": [

--- a/djangocon-2009/videos/django-technical-design-panel.json
+++ b/djangocon-2009/videos/django-technical-design-panel.json
@@ -11,7 +11,7 @@
   "slug": "django-technical-design-panel",
   "speakers": [
     "James Bennett",
-    "Dr. Russell Keith-Magee",
+    "Russell Keith-Magee",
     "Brian Rosner",
     "Joseph K",
     "Simon Willison"

--- a/djangocon-2009/videos/no--bad-pony.json
+++ b/djangocon-2009/videos/no--bad-pony.json
@@ -10,7 +10,7 @@
   "recorded": "2009-09-10",
   "slug": "no--bad-pony",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "",
   "tags": [

--- a/djangocon-2010/videos/djangocon-2010--dsf-announcements-and-q-amp-a.json
+++ b/djangocon-2010/videos/djangocon-2010--dsf-announcements-and-q-amp-a.json
@@ -10,7 +10,7 @@
   "recorded": "2010-09-07",
   "slug": "djangocon-2010--dsf-announcements-and-q-amp-a",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "",
   "tags": [

--- a/djangocon-2010/videos/djangocon-2010--first-steps-in-performance-tuning.json
+++ b/djangocon-2010/videos/djangocon-2010--first-steps-in-performance-tuning.json
@@ -10,7 +10,7 @@
   "recorded": "2010-09-08",
   "slug": "djangocon-2010--first-steps-in-performance-tuning",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "",
   "tags": [

--- a/djangocon-2010/videos/djangocon-2010--nosql-and-django-panel.json
+++ b/djangocon-2010/videos/djangocon-2010--nosql-and-django-panel.json
@@ -11,7 +11,7 @@
   "slug": "djangocon-2010--nosql-and-django-panel",
   "speakers": [
     "Jacob Burch",
-    "Dr. Russell Keith-Magee",
+    "Russell Keith-Magee",
     "Noah Silas",
     "Michael Richardson",
     "Eric Florenzano",

--- a/djangocon-2010/videos/djangocon-2010--so-you-want-to-be-a-core-develope.json
+++ b/djangocon-2010/videos/djangocon-2010--so-you-want-to-be-a-core-develope.json
@@ -10,7 +10,7 @@
   "recorded": "2010-09-07",
   "slug": "djangocon-2010--so-you-want-to-be-a-core-develope",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "",
   "tags": [

--- a/djangocon-2010/videos/djangocon-2010--sprints-kickoff.json
+++ b/djangocon-2010/videos/djangocon-2010--sprints-kickoff.json
@@ -10,7 +10,7 @@
   "recorded": "2010-09-09",
   "slug": "djangocon-2010--sprints-kickoff",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "",
   "tags": [

--- a/djangocon-2010/videos/djangocon-2010--technical-design-panel.json
+++ b/djangocon-2010/videos/djangocon-2010--technical-design-panel.json
@@ -12,7 +12,7 @@
   "speakers": [
     "Justin Braun",
     "Karen Tracy",
-    "Dr. Russell Keith-Magee",
+    "Russell Keith-Magee",
     "Brian Rosner",
     "Janis Leidel",
     "Gary Wilson"

--- a/djangocon-2011/videos/djangocon-2011--state-of-the-dsf-keynote.json
+++ b/djangocon-2011/videos/djangocon-2011--state-of-the-dsf-keynote.json
@@ -10,7 +10,7 @@
   "recorded": "2011-09-05",
   "slug": "djangocon-2011--state-of-the-dsf-keynote",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "",
   "tags": [

--- a/djangocon-2012/videos/djangocon-2012-keynote-russell-keith-magee.json
+++ b/djangocon-2012/videos/djangocon-2012-keynote-russell-keith-magee.json
@@ -10,7 +10,7 @@
   "recorded": "2012-10-06",
   "slug": "djangocon-2012-keynote-russell-keith-magee",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "DjangoCon 2012 - Keynote - Russell Keith-Magee\n",
   "tags": [

--- a/djangocon-2012/videos/get-off-the-bench-making-the-leap-from-user-to-c.json
+++ b/djangocon-2012/videos/get-off-the-bench-making-the-leap-from-user-to-c.json
@@ -10,7 +10,7 @@
   "recorded": "2012-09-06",
   "slug": "get-off-the-bench-making-the-leap-from-user-to-c",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "Django -- like all Open Source projects -- is only as good as the\ncommunity of people that contribute to it. We have a huge user\ncommunity, but the vast majority of users never make the leap and become\ncontributors. This talk will walk you through the process of making the\ntransition from Django user, to Django Project contributor.\n",
   "tags": [

--- a/djangocon-2013/videos/guerilla-apis-integrating-web-systems-that-werent.json
+++ b/djangocon-2013/videos/guerilla-apis-integrating-web-systems-that-werent.json
@@ -9,7 +9,7 @@
   "recorded": "2013-10-03",
   "slug": "guerilla-apis-integrating-web-systems-that-werent",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "GUERILLA APIS: INTEGRATING WEB SYSTEMS THAT WEREN'T DESIGNED TO BE\nINTEGRATED\n\nThursday 12:15 p.m.--1 p.m.\n\nAudience level: Intermediate\n\nDESCRIPTION In an ideal world, every web system would provide a well\ndesigned REST API with oAuth authentication. But what do you do when\nthose things don't exist?\n\nABSTRACT In an ideal world, every web system would provide a well\ndesigned REST API with oAuth authentication. But what do you do when\nthat doesn't exist?\n\nIn this talk, Russell Keith-Magee will explore some unorthodox\ntechniques for extracting and inserting information into the sort of\nsystems you see in the real world outside Silicon Valley -- systems that\ndon't provide a nice ReSTful API.\n",
   "tags": [],

--- a/djangocon-2013/videos/red-user-blue-user-myuser-auth-user.json
+++ b/djangocon-2013/videos/red-user-blue-user-myuser-auth-user.json
@@ -9,7 +9,7 @@
   "recorded": "2013-10-03",
   "slug": "red-user-blue-user-myuser-auth-user",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "Red User, Blue User, MyUser, auth.User\n\nWednesday 11:30 a.m.--12:15 p.m.\n\nAudience level: Intermediate\n\nDescription\n\nAn exploration of one of the banner features of Django 1.5 -- Custom\nUser models. Includes worked examples, a discussion of design decisions\nthat must be made, and a look at the internal architecture that makes it\nall possible. Abstract\n\nOne of the banner features of Django 1.5 was the introduction of custom\nUser models. Using this new feature, you are free to use any model you\nwish as your User, instead of being bound to the '30 character username\nand optional email' requirement of auth.User.\n\nIn this talk, Django core developer Russell Keith-Magee will give an\noverview of the API, and walk through some examples for some common --\nand some not so common -- use cases for a custom User.\n\nHe will also explore some common pitfalls and limitations of the custom\nUser model API, and look at the design decisions that face any use of\nthe custom User model API.\n\nFinally, we'll take a brief look under the hood to see how the feature\nactually works, and see how the same technique could be used for other\npluggable apps.\n",
   "tags": [],

--- a/djangocon-2014/videos/class-based-views-past-present-and-future.json
+++ b/djangocon-2014/videos/class-based-views-past-present-and-future.json
@@ -12,7 +12,7 @@
   ],
   "slug": "class-based-views-past-present-and-future",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "One of the big changes in Django 1.3 was the introduction of Class-Based\nViews. Opinion on them is strongly divided; some love them, some hate\nthem.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEo/\n",
   "tags": [],

--- a/djangocon-2014/videos/do-you-wanna-be-a-core-dev-you-dont-have-to-be-dev.json
+++ b/djangocon-2014/videos/do-you-wanna-be-a-core-dev-you-dont-have-to-be-dev.json
@@ -12,7 +12,7 @@
   ],
   "slug": "do-you-wanna-be-a-core-dev-you-dont-have-to-be-dev",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "The most important part of Django is it's community of contributors --\nwithout contributors, Django would never improve. However, while it's\nrelatively easy to work out how to use Django, the process of getting\ninvolved in development is a little more opaque. How does the the core\nteam operate? What tools and decision making processes exist? And how do\nyou, as a Django user, get involved?\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOPV/\n",
   "tags": [],

--- a/djangocon-2015/videos/i-am-a-doctor-tw-by-russell-keith-magee.json
+++ b/djangocon-2015/videos/i-am-a-doctor-tw-by-russell-keith-magee.json
@@ -9,7 +9,7 @@
   "recorded": "2015-09-18",
   "slug": "i-am-a-doctor-tw-by-russell-keith-magee",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "",
   "tags": [],

--- a/djangocon-2015/videos/i-never-meta-model-i-didnt-like-by-russell-keith.json
+++ b/djangocon-2015/videos/i-never-meta-model-i-didnt-like-by-russell-keith.json
@@ -9,7 +9,7 @@
   "recorded": "2015-09-18",
   "slug": "i-never-meta-model-i-didnt-like-by-russell-keith",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "I never Meta model I didn't like: The Django 1.8 Meta Interface\n\nThis talk will explain the new Meta API, and look at Daniel Pyrathon's\ndjango-mailer as an example of using Meta in the real world.\n\nTalk outline: What is meta programming - Reflection in Python - What\nthis means in Django History of Django's Meta The new Meta API -\nDaniel's GSoC project - API walkthrough So why bother? - How Forms use\nmeta - How Admin uses meta - django-mailer: GMail in contrib.admin \\*\nOther options? - A teaser of other places where this could be used.\n",
   "tags": [],

--- a/djangocon-2015/videos/lightning-talks-part-2.json
+++ b/djangocon-2015/videos/lightning-talks-part-2.json
@@ -20,7 +20,7 @@
     "Miroslav Shubernetskiy",
     "Armin Ronacher",
     "Brendan Sterne",
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "Lightning Talks\n\nDmitry Filippov \"Django assistance in PyCharm\"\n\nPaul Bailey \"End the Holy Wars of Formatting\"\n\nTrey Hunner \"JavaScript is Becoming Pythonic\"\n\nEduardo Rivas \" Sublime Text Django\"\n\nJeff Sumner \"Texas Swim Center\"\n\nFrancisco Saldana \"Keeping Fast Fast: Rapid Iteration with\nTransactionTestCase\"\n\nRaphael Merx \"Mocking Outbound Requests with HTTPretty\"\n\nJames Tauber \"Building a Learning Management System with Pinax\"\n\nMiroslav Shubernetskiy \"Filtering in Django\"\n\nArmin Ronacher \"rb - Scaling Redis in Python\"\n\nBrendan Sterne \"Code Wiki\"\n\nRussell Keith-Magee \"Professional Yak Coiffure\"\n",
   "tags": [

--- a/djangocon-2015/videos/money-money-money-by-russell-keith-magee.json
+++ b/djangocon-2015/videos/money-money-money-by-russell-keith-magee.json
@@ -9,7 +9,7 @@
   "recorded": "2015-09-18",
   "slug": "money-money-money-by-russell-keith-magee",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "Money, Money, Money - Writing software, in a rich (wo)man's world\n\nFree software advocates talk about two types of \"Free\": Free as in\nfreedom, and Free as in beer. While Free (as in freedom) software is\nunquestionably better for users and developers alike, Free (as in beer)\nsoftware doesn't pay the bills.\n\nTalk to any prominent open source developer, and amongst the success\nstories, you'll also hear some consistent troubles - that they've got\ngreat ideas and grand plans, but no time to execute; that they're about\nto burn out due to the pressues of maintaining their project; or that\nthey've had yet another mailing list discussion with someone who doesn't\nunderstand they're a volunteer. All of these problems stem from a\nfundamental disconnect: the discrepancy between the clear demand for a\nsoftware product, and the ability to convert that demand into time\nneeded to service that demand - and that means money.\n",
   "tags": [],

--- a/djangocon-au-2013/videos/secrets-of-the-testing-masters.json
+++ b/djangocon-au-2013/videos/secrets-of-the-testing-masters.json
@@ -10,7 +10,7 @@
   "recorded": "2013-07-05",
   "slug": "secrets-of-the-testing-masters",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "Django ship with a wide range of tools to help you test your web\napplication, but some of the best tools for testing Django don't come in\nthe box.\n\nIn this talk, you'll get a brief introduction to two of those tools -\nMock and Factory Boy - showing when they should be used, and some\npractical examples of their usage in a Django test suite.\n",
   "tags": [],

--- a/djangocon-eu-2010/videos/djangoconeu-djangotechnicaldesignpanel420flv.json
+++ b/djangocon-eu-2010/videos/djangoconeu-djangotechnicaldesignpanel420flv.json
@@ -10,7 +10,7 @@
   "recorded": "2010-05-25",
   "slug": "djangoconeu-djangotechnicaldesignpanel420flv",
   "speakers": [
-    "Dr. Russell Keith-Magee",
+    "Russell Keith-Magee",
     "Jan Lehnardt",
     "Jacob Kaplan-Moss",
     "Alex Gaynor"

--- a/djangocon-eu-2010/videos/djangoconeu-lightingtalksthirdday663flv.json
+++ b/djangocon-eu-2010/videos/djangoconeu-lightingtalksthirdday663flv.json
@@ -11,7 +11,7 @@
   "slug": "djangoconeu-lightingtalksthirdday663flv",
   "speakers": [
     "Jan Lehnardt",
-    "Dr. Russell Keith-Magee",
+    "Russell Keith-Magee",
     "Ville S\u00e4\u00e4vuori",
     "Remco Wendt",
     "Horst Gutmann",

--- a/djangocon-eu-2010/videos/djangoconeu-russellkeithmageenobadponyorexplainin.json
+++ b/djangocon-eu-2010/videos/djangoconeu-russellkeithmageenobadponyorexplainin.json
@@ -10,7 +10,7 @@
   "recorded": "2010-05-25",
   "slug": "djangoconeu-russellkeithmageenobadponyorexplainin",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "",
   "tags": [],

--- a/djangocon-eu-2013/videos/djangocon-eu-2013-russell-keith-magee-class-based-views-untangling-the-mess.json
+++ b/djangocon-eu-2013/videos/djangocon-eu-2013-russell-keith-magee-class-based-views-untangling-the-mess.json
@@ -2,7 +2,7 @@
   "description": "Videos from DjangoCon Europe 2013 are kindly provided by Heroku, a cloud application platform -- a new way of building and deploying web apps: http://heroku.com/",
   "recorded": "2013-05-15",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/TZQ5eFVQmu0/hqdefault.jpg",
   "title": "DjangoCon EU 2013: Russell Keith-Magee - Class-Based Views: Untangling the mess",

--- a/djangocon-eu-2015/videos/i-am-a-doctor.json
+++ b/djangocon-eu-2015/videos/i-am-a-doctor.json
@@ -9,7 +9,7 @@
   "recorded": "2015-08-10",
   "slug": "russel-keith-magee-i-am-a-doctor-at-djangocon-2015",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "",
   "tags": [],

--- a/djangocon-eu-2015/videos/what-on-earth-are-python-django.json
+++ b/djangocon-eu-2015/videos/what-on-earth-are-python-django.json
@@ -9,7 +9,7 @@
   "recorded": "2015-08-08",
   "slug": "russell-keith-magee-what-on-earth-are-python-at",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "",
   "tags": [],

--- a/djangocon-eu-2016/videos/beyond-web-2-0-django-and-python-in-the-modern-web-ecosystem.json
+++ b/djangocon-eu-2016/videos/beyond-web-2-0-django-and-python-in-the-modern-web-ecosystem.json
@@ -3,7 +3,7 @@
   "language": "eng",
   "recorded": "2016-04-01",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "tags": [
     "django"

--- a/djangocon-eu-2017/videos/all-about-community-panel-with-anna-makarudze-anna-ossowski-erik-romjin-russel-keith-magee.json
+++ b/djangocon-eu-2017/videos/all-about-community-panel-with-anna-makarudze-anna-ossowski-erik-romjin-russel-keith-magee.json
@@ -4,7 +4,7 @@
   "language": "eng",
   "recorded": "2017-04-04",
   "speakers": [
-    "Dr. Russell Keith-Magee",
+    "Russell Keith-Magee",
     "Erik Romijn",
     "Anna Ossowski",
     "Anna Makarudze"

--- a/djangocon-eu-2017/videos/autopsy-of-a-slow-train-wreck-the-life-and-death-of-a-django-startup-by-russell-keith-magee.json
+++ b/djangocon-eu-2017/videos/autopsy-of-a-slow-train-wreck-the-life-and-death-of-a-django-startup-by-russell-keith-magee.json
@@ -10,7 +10,7 @@
     }
   ],
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/DnR9PZS5WGE/hqdefault.jpg",

--- a/djangocon-eu-2017/videos/lighting-talks-tuesday.json
+++ b/djangocon-eu-2017/videos/lighting-talks-tuesday.json
@@ -7,7 +7,7 @@
     "Alexander Gaevsky",
     "Joachim Jablon",
     "Idan Melamed",
-    "Dr. Russell Keith-Magee",
+    "Russell Keith-Magee",
     "Sergei Maertens",
     "Antonis Christofides"
   ],

--- a/djangocon-eu-2018/videos/djangocon-2018-its-about-time.json
+++ b/djangocon-eu-2018/videos/djangocon-2018-its-about-time.json
@@ -4,7 +4,7 @@
   "language": "eng",
   "recorded": "2018-05-25",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/qabriMQ1SYs/hqdefault.jpg",
   "title": "It's about time",

--- a/djangocon-eu-2018/videos/djangocon-2018-lightning-talks-ii.json
+++ b/djangocon-eu-2018/videos/djangocon-2018-lightning-talks-ii.json
@@ -10,7 +10,7 @@
     "Leila Verhaegen",
     "Lorenzo Pe\u00f1a",
     "Daniel Hepper",
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/bWvehdCSvLA/hqdefault.jpg",
   "title": "Day 2 Lightning Talks",

--- a/djangocon-us-2016/videos/djangocon-us-2016-lightning-talks-by-many-people.json
+++ b/djangocon-us-2016/videos/djangocon-us-2016-lightning-talks-by-many-people.json
@@ -5,7 +5,7 @@
   "recorded": "2016-07-18",
   "speakers": [
     "Adrienne Lowe",
-    "Dr. Russell Keith-Magee",
+    "Russell Keith-Magee",
     "Tom Christie",
     "Trey Hunner",
     "Paul Logston",

--- a/djangocon-us-2016/videos/djangocon-us-2016-making-a-splash-with-your-open-source-project-by-russell-keith-magee.json
+++ b/djangocon-us-2016/videos/djangocon-us-2016-making-a-splash-with-your-open-source-project-by-russell-keith-magee.json
@@ -6,7 +6,7 @@
   "recorded": "2016-08-12",
   "related_urls": [],
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/MrXXYBr1rlA/maxresdefault.jpg",

--- a/djangocon-us-2016/videos/djangocon-us-2016-things-your-mother-didnt-teach-you-about-by-russell-keith-magee.json
+++ b/djangocon-us-2016/videos/djangocon-us-2016-things-your-mother-didnt-teach-you-about-by-russell-keith-magee.json
@@ -4,7 +4,7 @@
   "language": "eng",
   "recorded": "2016-07-19",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/H-r8JwrmN58/hqdefault.jpg",
   "title": "Things Your Mother Didn't Teach You About Sharing Your Toys",

--- a/pycon-au-2010/videos/pyconau-2010--what--39-s-new-in-django-1-2.json
+++ b/pycon-au-2010/videos/pyconau-2010--what--39-s-new-in-django-1-2.json
@@ -10,7 +10,7 @@
   "recorded": "2010-06-26",
   "slug": "pyconau-2010--what--39-s-new-in-django-1-2",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "",
   "tags": [

--- a/pycon-au-2011/videos/panel-python-in-the-webs.json
+++ b/pycon-au-2011/videos/panel-python-in-the-webs.json
@@ -13,7 +13,7 @@
     "Dylan Jay",
     "Malcolm Tredinnick",
     "Richard Jones",
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "This will be a panel discussion wherein we wax philosophical about the\nstate of web frameworks in Python - talking about invention,\nreinvention, multitudes of choice, how all of them suck, etc. Panelists\nwill include Dylan Jay, Malcolm Tredinnick, Russell Keith-Magee and\nRichard Jones.\n",
   "tags": [

--- a/pycon-au-2012/videos/no-bad-pony.json
+++ b/pycon-au-2012/videos/no-bad-pony.json
@@ -10,7 +10,7 @@
   "recorded": "2012-08-22",
   "slug": "no-bad-pony",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "The Django community is not short of ideas that could be added to the\ncore repository. Some of these ideas are great, and are just waiting for\nthe right implementation or the attention of a core developer. Other\nideas are just not going to happen. However, it's not always obvious why\nan idea will be rejected. This talk will attempt explain the reasoning\nbehind a couple of specific decisions. More broadly, this talk will aims\nto provide general guidance on the decision making process of the Django\ncore. It will also address how you can get started contributing to\nDjango.\n",
   "tags": [

--- a/pycon-au-2013/videos/tinkering-with-tkinter.json
+++ b/pycon-au-2013/videos/tinkering-with-tkinter.json
@@ -10,7 +10,7 @@
   "recorded": "2013-07-07",
   "slug": "tinkering-with-tkinter",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "Tkinter - the Python wrapper to the Tk graphics library - has been part\nof the Python standard library since very early on. However, that\ninclusion hasn't translated into extensive use.\n\nThere was a very good reason for this. Tk's documentation was beyond\nawful. And if you managed to get over that hurdle, Tkinter apps looked\nawful - they had a woefully inadequate set of widgets, styled with the\nvery best of mid 1990's open source graphic skill.\n\nAnd then, the world got obsessed with web frameworks, and the desktop\nwas declared as dead.\n\nHowever, in the last few years, many of the reasons Tkinter was ignored\nhave been quietly fixed. Tk 8.4 massively improved the visual appearance\nof Tk. tkdocs.com has emerged, addressing many of the problems with Tk\ndocumentation.\n\nIn this talk, you'll get a re-introduction to an old friend, and an\nexplanation of why, in a web and mobile world, you should care.\n",
   "tags": [],

--- a/pycon-au-2014/videos/grug-make-fire-grug-make-wheel-by-russell-keith.json
+++ b/pycon-au-2014/videos/grug-make-fire-grug-make-wheel-by-russell-keith.json
@@ -10,7 +10,7 @@
   "recorded": "2014-08-11",
   "slug": "grug-make-fire-grug-make-wheel-by-russell-keith",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "",
   "tags": [],

--- a/pycon-au-2015/videos/core-team-panel-featuring-chris-beaven-markus.json
+++ b/pycon-au-2015/videos/core-team-panel-featuring-chris-beaven-markus.json
@@ -13,7 +13,7 @@
     "Chris Beaven",
     "Curtis Maloney",
     "Markus Holtermann",
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "",
   "tags": [],

--- a/pycon-au-2015/videos/money-money-money-writing-software-in-a-rich.json
+++ b/pycon-au-2015/videos/money-money-money-writing-software-in-a-rich.json
@@ -10,7 +10,7 @@
   "recorded": "2015-08-04",
   "slug": "money-money-money-writing-software-in-a-rich",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "",
   "tags": [],

--- a/pycon-au-2015/videos/python-on-the-move-the-state-of-mobile-python.json
+++ b/pycon-au-2015/videos/python-on-the-move-the-state-of-mobile-python.json
@@ -10,7 +10,7 @@
   "recorded": "2015-08-04",
   "slug": "python-on-the-move-the-state-of-mobile-python",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "summary": "",
   "tags": [],

--- a/pycon-au-2016/videos/python-all-the-things.json
+++ b/pycon-au-2016/videos/python-all-the-things.json
@@ -8,7 +8,7 @@
     "https://2016.pycon-au.org/schedule/198/view_talk"
   ],
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/1sDyVJm3Ht0/maxresdefault.jpg",

--- a/pycon-au-2017/videos/covered-in-bees-deploying-an-app-to-6-platforms-in-20-minutes.json
+++ b/pycon-au-2017/videos/covered-in-bees-deploying-an-app-to-6-platforms-in-20-minutes.json
@@ -4,7 +4,7 @@
   "language": "eng",
   "recorded": "2017-08-05",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/xezYYBL7nk0/hqdefault.jpg",
   "title": "Covered in Bees! Deploying an app to 6 platforms in 20 minutes",

--- a/pycon-au-2017/videos/lightning-talks-sunday.json
+++ b/pycon-au-2017/videos/lightning-talks-sunday.json
@@ -6,7 +6,7 @@
     "Sam Kitajima-Kimbrel",
     "Jason King",
     "Evan Kohilas",
-    "Dr. Russell Keith-Magee",
+    "Russell Keith-Magee",
     "William Brown",
     "Allen Rueben",
     "Malcolm Ramsay",

--- a/pycon-au-2017/videos/red-user-blue-user-myuser-authuser.json
+++ b/pycon-au-2017/videos/red-user-blue-user-myuser-authuser.json
@@ -4,7 +4,7 @@
   "language": "eng",
   "recorded": "2017-08-04",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/458KmAKq0bQ/hqdefault.jpg",
   "title": "Red User, Blue User, MyUser, auth.User",

--- a/pycon-ru-2013/videos/building-a-development-community-lessons-and-challenges.json
+++ b/pycon-ru-2013/videos/building-a-development-community-lessons-and-challenges.json
@@ -3,7 +3,7 @@
   "duration": 3585,
   "recorded": "2013-02-24",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/cvU6vQFugsc/hqdefault.jpg",
   "title": "Building a development community: Lessons and challenges",

--- a/pycon-ru-2013/videos/django-16-and-beyond-the-django-roadmap.json
+++ b/pycon-ru-2013/videos/django-16-and-beyond-the-django-roadmap.json
@@ -3,7 +3,7 @@
   "duration": 3698,
   "recorded": "2013-02-25",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/zPrEgGAXdhI/hqdefault.jpg",
   "title": "Django 1.6 and beyond: The Django Roadmap",

--- a/pycon-us-2016/videos/russell-keith-magee-a-tale-of-two-cellphones-python-on-android-and-ios-pycon-2016.json
+++ b/pycon-us-2016/videos/russell-keith-magee-a-tale-of-two-cellphones-python-on-android-and-ios-pycon-2016.json
@@ -11,7 +11,7 @@
   ],
   "slug": "russell-keith-magee-a-tale-of-two-cellphones-python-on-android-and-ios-pycon-2016",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/NqdpK9KjGgQ/maxresdefault.jpg",

--- a/pycon-us-2017/videos/russell-keith-magee-how-to-write-a-python-transpiler-pycon-2017.json
+++ b/pycon-us-2017/videos/russell-keith-magee-how-to-write-a-python-transpiler-pycon-2017.json
@@ -3,7 +3,7 @@
   "duration": 1843,
   "recorded": "2017-05-20",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/9c4DEYIXYCM/hqdefault.jpg",
   "title": "How to write a Python transpiler",

--- a/pyohio-2016/videos/snakes-in-a-browser.json
+++ b/pyohio-2016/videos/snakes-in-a-browser.json
@@ -3,7 +3,7 @@
   "duration": 1200,
   "recorded": "2016-07-31",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/9W2sFRrNJ9A/maxresdefault.jpg",
   "title": "Snakes in a Browser",

--- a/pythonbrasil-2016/videos/keynote-russell-keith-magee-python-all-the-things.json
+++ b/pythonbrasil-2016/videos/keynote-russell-keith-magee-python-all-the-things.json
@@ -3,7 +3,7 @@
   "duration": 3186,
   "recorded": "2016-10-17",
   "speakers": [
-    "Dr. Russell Keith-Magee"
+    "Russell Keith-Magee"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/raiAxB1Scms/hqdefault.jpg",
   "title": "Keynote: Python all the things!",


### PR DESCRIPTION
As per the discussion on Ticket #62, this PR replaces all the references to "Dr. Russell Keith-Magee" with "Russell Keith-Magee". 

I currently have records in both locations in the index, and the version without prefix is my preferred form for indexing purposes.