### PR TITLE
Merged records for Amber 'hawkowl' Brown.

### DIFF
--- a/europython-2016/videos/amber-brown-the-report-of-twisteds-death.json
+++ b/europython-2016/videos/amber-brown-the-report-of-twisteds-death.json
@@ -8,7 +8,7 @@
     "https://ep2016.europython.eu//conference/talks/the-report-of-twisteds-death"
   ],
   "speakers": [
-    "Amber Brown"
+    "Amber Brown (\"HawkOwl\")"
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/UkkO3_GSR2g/maxresdefault.jpg",

--- a/pycon-au-2015/videos/slow-down-compose-yourself.json
+++ b/pycon-au-2015/videos/slow-down-compose-yourself.json
@@ -10,7 +10,7 @@
   "recorded": "2015-08-04",
   "slug": "slow-down-compose-yourself",
   "speakers": [
-    "Amber \"Hawkie\" Brown"
+    "Amber Brown"
   ],
   "summary": "",
   "tags": [],

--- a/pycon-au-2015/videos/slow-down-compose-yourself.json
+++ b/pycon-au-2015/videos/slow-down-compose-yourself.json
@@ -10,7 +10,7 @@
   "recorded": "2015-08-04",
   "slug": "slow-down-compose-yourself",
   "speakers": [
-    "Amber Brown"
+    "Amber Brown (\"HawkOwl\")"
   ],
   "summary": "",
   "tags": [],

--- a/pycon-au-2015/videos/what-django-can-learn-from-twisted.json
+++ b/pycon-au-2015/videos/what-django-can-learn-from-twisted.json
@@ -10,7 +10,7 @@
   "recorded": "2015-08-04",
   "slug": "what-django-can-learn-from-twisted",
   "speakers": [
-    "Amber Brown"
+    "Amber Brown (\"HawkOwl\")"
   ],
   "summary": "",
   "tags": [],

--- a/pycon-au-2015/videos/what-django-can-learn-from-twisted.json
+++ b/pycon-au-2015/videos/what-django-can-learn-from-twisted.json
@@ -10,7 +10,7 @@
   "recorded": "2015-08-04",
   "slug": "what-django-can-learn-from-twisted",
   "speakers": [
-    "Amber \"Hawkie\" Brown"
+    "Amber Brown"
   ],
   "summary": "",
   "tags": [],

--- a/pycon-au-2016/videos/releasing-calendar-versioned-software.json
+++ b/pycon-au-2016/videos/releasing-calendar-versioned-software.json
@@ -8,7 +8,7 @@
     "https://2016.pycon-au.org/schedule/144/view_talk"
   ],
   "speakers": [
-    "Amber Brown"
+    "Amber Brown (\"HawkOwl\")"
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/m44brj9PwPA/maxresdefault.jpg",

--- a/pycon-au-2017/videos/concurrency-and-parallelism-from-the-ground-up.json
+++ b/pycon-au-2017/videos/concurrency-and-parallelism-from-the-ground-up.json
@@ -4,7 +4,7 @@
   "language": "eng",
   "recorded": "2017-08-05",
   "speakers": [
-    "Amber Brown"
+    "Amber Brown (\"HawkOwl\")"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/gJ6loj3nB4s/hqdefault.jpg",
   "title": "Concurrency and Parallelism From The Ground Up",

--- a/pycon-us-2016/videos/the-report-of-twisteds-death-or-why-twisted-and-tornado-are-relevant-in-the-asyncio-age.json
+++ b/pycon-us-2016/videos/the-report-of-twisteds-death-or-why-twisted-and-tornado-are-relevant-in-the-asyncio-age.json
@@ -11,7 +11,7 @@
   ],
   "slug": "the-report-of-twisteds-death-or-why-twisted-and-tornado-are-relevant-in-the-asyncio-age",
   "speakers": [
-    "Amber Brown"
+    "Amber Brown (\"HawkOwl\")"
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/82vuCZ4FLFE/maxresdefault.jpg",

--- a/pycon-us-2017/videos/amber-brown-implementing-concurrency-and-parallelism-from-the-ground-up-pycon-2017.json
+++ b/pycon-us-2017/videos/amber-brown-implementing-concurrency-and-parallelism-from-the-ground-up-pycon-2017.json
@@ -3,7 +3,7 @@
   "duration": 1960,
   "recorded": "2017-05-19",
   "speakers": [
-    "Amber Brown"
+    "Amber Brown (\"HawkOwl\")"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/31fXwpb0P9c/hqdefault.jpg",
   "title": "Implementing Concurrency and Parallelism From The Ground Up",

--- a/pycon-us-2018/videos/amber-brown-hawkowl-how-we-do-identity-wrong-pycon-2018.json
+++ b/pycon-us-2018/videos/amber-brown-hawkowl-how-we-do-identity-wrong-pycon-2018.json
@@ -23,7 +23,7 @@
     }
   ],
   "speakers": [
-    "Amber Brown"
+    "Amber Brown (\"HawkOwl\")"
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/A5tPhUKljuY/maxresdefault.jpg",

--- a/pycon-us-2018/videos/amber-brown-hawkowl-how-we-do-identity-wrong-pycon-2018.json
+++ b/pycon-us-2018/videos/amber-brown-hawkowl-how-we-do-identity-wrong-pycon-2018.json
@@ -23,7 +23,7 @@
     }
   ],
   "speakers": [
-    "Amber Brown (\"HawkOwl\")"
+    "Amber Brown"
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/A5tPhUKljuY/maxresdefault.jpg",


### PR DESCRIPTION
Amber Brown commonly identifies herself with her online handle "@hawkowl"; as a result, she has three records in the PyVideo index.

I have reached out to Amber to seek clarification on her preferred name for indexing purposes (as per #62):

https://twitter.com/freakboy3742/status/1069370416613941250

In the meantime, this PR consolidates her talks into the record that currently contains the most talks.