### PR TITLE
Fixing data related to Philip James

### DIFF
--- a/bay-piggies/videos/baypiggies-april-2017-talk-annual-pycon-preview.json
+++ b/bay-piggies/videos/baypiggies-april-2017-talk-annual-pycon-preview.json
@@ -5,8 +5,6 @@
   "speakers": [
     "Moshe Zadka",
     "Al Sweigart",
-    "Asheesh Laroia",
-    "Philip James"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/MksyISonCws/hqdefault.jpg",
   "title": "BayPIGgies April 2017 talk: Annual PyCon Preview",

--- a/bay-piggies/videos/baypiggies-april-2017-talk-annual-pycon-preview.json
+++ b/bay-piggies/videos/baypiggies-april-2017-talk-annual-pycon-preview.json
@@ -4,7 +4,7 @@
   "recorded": "2017-04-27",
   "speakers": [
     "Moshe Zadka",
-    "Al Sweigart",
+    "Al Sweigart"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/MksyISonCws/hqdefault.jpg",
   "title": "BayPIGgies April 2017 talk: Annual PyCon Preview",

--- a/north-bay-python-2018/videos/all-in-the-timing-how-side-channel-attacks-work.json
+++ b/north-bay-python-2018/videos/all-in-the-timing-how-side-channel-attacks-work.json
@@ -16,7 +16,7 @@
     }
   ],
   "speakers": [
-    "Philip \"Phildini\" James",
+    "Philip James",
     "Asheesh Laroia"
   ],
   "tags": [],


### PR DESCRIPTION
Two fixes here:
1) Asheesh and I did not end up speaking at the BayPiggies event, even though we were scheduled to
2) Standardizing the name "Philip James" to be the standard (removing nom de plume)