### PR TITLE
Add speakers to PyData NYC 2018

### DIFF
--- a/pydata-new-york-city-2018/videos/a-bluffer-s-guide-to-dimension-reduction-leland-mcinnes.json
+++ b/pydata-new-york-city-2018/videos/a-bluffer-s-guide-to-dimension-reduction-leland-mcinnes.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Leland McInnes"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/9iol3Lk6kyU/maxresdefault.jpg",
-  "title": "A Bluffer's Guide to Dimension Reduction - Leland McInnes",
+  "title": "A Bluffer's Guide to Dimension Reduction",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/a-data-scientist-s-guide-to-production-web-apps-with-flask-ali-vanderveld.json
+++ b/pydata-new-york-city-2018/videos/a-data-scientist-s-guide-to-production-web-apps-with-flask-ali-vanderveld.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Ali Vanderveld"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/z-Ue9T0MpVs/maxresdefault.jpg",
-  "title": "A data scientist's guide to production web apps with Flask - Ali Vanderveld",
+  "title": "A data scientist's guide to production web apps with Flask",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/conda-forge-community-driven-packaging-that-works-for-you-marius-van-niekerk.json
+++ b/pydata-new-york-city-2018/videos/conda-forge-community-driven-packaging-that-works-for-you-marius-van-niekerk.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Marius van Niekerk"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/qHdRPoPYiHE/maxresdefault.jpg",
-  "title": "Conda Forge - Community Driven Packaging That Works for You - Marius van Niekerk",
+  "title": "Conda Forge - Community Driven Packaging That Works for You",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/contract-testing-in-python-for-a-data-science-api-j-scott-hajek.json
+++ b/pydata-new-york-city-2018/videos/contract-testing-in-python-for-a-data-science-api-j-scott-hajek.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "J. Scott Hajek"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/plR0Qd-BexU/maxresdefault.jpg",
-  "title": "Contract Testing in Python for a Data Science API - J. Scott Hajek",
+  "title": "Contract Testing in Python for a Data Science API",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/contributing-to-open-source-a-guide-paul-ganssle.json
+++ b/pydata-new-york-city-2018/videos/contributing-to-open-source-a-guide-paul-ganssle.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Paul Ganssle"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/JhPC6_rO08s/maxresdefault.jpg",
-  "title": "Contributing to Open Source: A Guide - Paul Ganssle",
+  "title": "Contributing to Open Source: A Guide",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/contributing-to-open-source-a-guide-paul-ganssle.json
+++ b/pydata-new-york-city-2018/videos/contributing-to-open-source-a-guide-paul-ganssle.json
@@ -1,6 +1,6 @@
 {
-  "copyright_text": null,
-  "description": "",
+  "copyright_text": "CC-0",
+  "description": "Contributing to open source can be a rewarding experience, but many people don't know how, or find the process confusing or frustrating. This talk tries to bridge both the technical and social gap between new contributors and maintainers to help the listener have a positive open source experience.",
   "duration": 1910,
   "language": "eng",
   "recorded": "2018-08-17",
@@ -8,6 +8,18 @@
     {
       "label": "Conference schedule",
       "url": "https://pydata.org/nyc2018/schedule/"
+    },
+    {
+      "label": "Abstract",
+      "url": "https://pydata.org/nyc2018/schedule/presentation/26/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pganssle-talks.github.io/pydata-nyc-2018-open-source"
+    },
+    {
+      "label": "Github Repository",
+      "url": "https://github.com/pganssle-talks/pydata-nyc-2018-open-source"
     }
   ],
   "speakers": [

--- a/pydata-new-york-city-2018/videos/crunching-your-data-with-catboost-the-new-gradient-boosting-library-vasily-ershov.json
+++ b/pydata-new-york-city-2018/videos/crunching-your-data-with-catboost-the-new-gradient-boosting-library-vasily-ershov.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Vasily Ershov"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/37wdnpdyls4/maxresdefault.jpg",
-  "title": "Crunching Your Data with CatBoost - the New Gradient Boosting Library - Vasily Ershov",
+  "title": "Crunching Your Data with CatBoost - the New Gradient Boosting Library",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/data-science-in-healthcare-beyond-the-hype-michael-becker.json
+++ b/pydata-new-york-city-2018/videos/data-science-in-healthcare-beyond-the-hype-michael-becker.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Michael Becker"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/Z9JZjc489XA/maxresdefault.jpg",
-  "title": "Data Science in Healthcare: Beyond the Hype - Michael Becker",
+  "title": "Data Science in Healthcare: Beyond the Hype",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/deploying-data-science-for-distribution-of-the-new-york-times-anne-bauer.json
+++ b/pydata-new-york-city-2018/videos/deploying-data-science-for-distribution-of-the-new-york-times-anne-bauer.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Anne Bauer"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/ML02prDasx4/maxresdefault.jpg",
-  "title": "Deploying Data Science for Distribution of The New York Times - Anne Bauer",
+  "title": "Deploying Data Science for Distribution of The New York Times",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/end-to-end-data-science-without-leaving-the-gpu-randy-zwitch.json
+++ b/pydata-new-york-city-2018/videos/end-to-end-data-science-without-leaving-the-gpu-randy-zwitch.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Randy Zwitch"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/gQszQcFHcZc/maxresdefault.jpg",
-  "title": "End to End Data Science Without Leaving The GPU - Randy Zwitch",
+  "title": "End to End Data Science Without Leaving The GPU",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/functional-programming-for-data-scientists-santiago-basulto.json
+++ b/pydata-new-york-city-2018/videos/functional-programming-for-data-scientists-santiago-basulto.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Santiago Basulto"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/wVAEOHqC3Cg/maxresdefault.jpg",
-  "title": "Functional Programming for Data Scientists - Santiago Basulto",
+  "title": "Functional Programming for Data Scientists",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/going-beyond-sorry-i-didnt-get-that-building-ai-assistants-that-scale-justina-petraityte.json
+++ b/pydata-new-york-city-2018/videos/going-beyond-sorry-i-didnt-get-that-building-ai-assistants-that-scale-justina-petraityte.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Justina Petraitytė"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/krOhH0RKQ6A/maxresdefault.jpg",
-  "title": "Going Beyond \u201cSorry, I Didn\u2019t Get That\u201d: Building AI Assistants that Scale... - Justina Petraityt\u0117",
+  "title": "Going Beyond “Sorry, I Didn’t Get That”: Building AI Assistants that Scale...",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/graph-analytics-from-the-whiteboard-to-your-toolbox-sam-lerma.json
+++ b/pydata-new-york-city-2018/videos/graph-analytics-from-the-whiteboard-to-your-toolbox-sam-lerma.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Sam Lerma"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/eUwXgCv2QCE/maxresdefault.jpg",
-  "title": "Graph Analytics - From the Whiteboard to Your Toolbox - Sam Lerma",
+  "title": "Graph Analytics - From the Whiteboard to Your Toolbox",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/hdbscan-fast-density-based-clustering-the-how-and-the-why-john-healy.json
+++ b/pydata-new-york-city-2018/videos/hdbscan-fast-density-based-clustering-the-how-and-the-why-john-healy.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "John Healy"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/dGsxd67IFiU/maxresdefault.jpg",
-  "title": "HDBSCAN, Fast Density Based Clustering, the How and the Why - John Healy",
+  "title": "HDBSCAN, Fast Density Based Clustering, the How and the Why",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/hierarchical-probabilistic-modelling-in-real-life-benjamin-batorsky-matthew-moocarme-ph-d.json
+++ b/pydata-new-york-city-2018/videos/hierarchical-probabilistic-modelling-in-real-life-benjamin-batorsky-matthew-moocarme-ph-d.json
@@ -10,10 +10,13 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Benjamin Batorsky",
+    "Matthew Moocarme"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/bAdHn17IyqA/maxresdefault.jpg",
-  "title": "Hierarchical Probabilistic Modelling in Real Life - Benjamin Batorsky, Matthew Moocarme, Ph.D.",
+  "title": "Hierarchical Probabilistic Modelling in Real Life",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/how-to-spend-3-4-of-your-yearly-budget-in-3-weeks-a-pyspark-cautionary-tale-nicole-carlson.json
+++ b/pydata-new-york-city-2018/videos/how-to-spend-3-4-of-your-yearly-budget-in-3-weeks-a-pyspark-cautionary-tale-nicole-carlson.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Nicole Carlson"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/SFkmrgfwEyE/maxresdefault.jpg",
-  "title": "How to spend \u00be of your yearly budget in 3 weeks: a PySpark cautionary tale - Nicole Carlson",
+  "title": "How to spend ¾ of your yearly budget in 3 weeks: a PySpark cautionary tale",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/intake-taking-the-pain-out-of-data-access-martin-durant.json
+++ b/pydata-new-york-city-2018/videos/intake-taking-the-pain-out-of-data-access-martin-durant.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Martin Durant"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/pjkMmJQfTb8/maxresdefault.jpg",
-  "title": "Intake: Taking the Pain Out of Data Access - Martin Durant",
+  "title": "Intake: Taking the Pain Out of Data Access",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/introduction-to-big-data-processing-using-spark-and-python-raoul-gabriel-urma.json
+++ b/pydata-new-york-city-2018/videos/introduction-to-big-data-processing-using-spark-and-python-raoul-gabriel-urma.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Raoul-Gabriel Urma"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/ELlLGbmnjBk/maxresdefault.jpg",
-  "title": "Introduction to Big Data Processing using Spark and Python - Raoul-Gabriel Urma",
+  "title": "Introduction to Big Data Processing using Spark and Python",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/iodide-and-pyodide-bringing-data-science-computation-to-the-web-browser-michael-droettboom.json
+++ b/pydata-new-york-city-2018/videos/iodide-and-pyodide-bringing-data-science-computation-to-the-web-browser-michael-droettboom.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Michael Droettboom"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/iUqVgykaF-k/maxresdefault.jpg",
-  "title": "Iodide and Pyodide: Bringing Data Science Computation to the Web Browser - Michael Droettboom",
+  "title": "Iodide and Pyodide: Bringing Data Science Computation to the Web Browser",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/james-powell.json
+++ b/pydata-new-york-city-2018/videos/james-powell.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "James Powell"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/65_-6kEAq58/maxresdefault.jpg",
-  "title": "\u2026 - James Powell",
+  "title": "…",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/making-faces-conditional-generation-of-faces-using-gans-sophia-r-searcy-justin-blinder.json
+++ b/pydata-new-york-city-2018/videos/making-faces-conditional-generation-of-faces-using-gans-sophia-r-searcy-justin-blinder.json
@@ -10,10 +10,13 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Sophia R Searcy",
+    "Justin Blinder"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/5zqAj03ODII/maxresdefault.jpg",
-  "title": "Making Faces: Conditional Generation of Faces using GANs... - Sophia R Searcy, Justin Blinder",
+  "title": "Making Faces: Conditional Generation of Faces using GANs...",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/measuring-model-fairness-j-henry-hinnefeld.json
+++ b/pydata-new-york-city-2018/videos/measuring-model-fairness-j-henry-hinnefeld.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "J. Henry Hinnefeld"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/V3tmxMf2UH8/maxresdefault.jpg",
-  "title": "Measuring Model Fairness - J. Henry Hinnefeld",
+  "title": "Measuring Model Fairness",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/open-the-black-box-an-introduction-to-model-interpretability-with-lime-and-shap-kevin-lemagnen.json
+++ b/pydata-new-york-city-2018/videos/open-the-black-box-an-introduction-to-model-interpretability-with-lime-and-shap-kevin-lemagnen.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Kevin Lemagnen"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/C80SQe16Rao/maxresdefault.jpg",
-  "title": "Open the Black Box: an Introduction to Model Interpretability with LIME and SHAP - Kevin Lemagnen",
+  "title": "Open the Black Box: an Introduction to Model Interpretability with LIME and SHAP",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/pandas-integer-na-as-a-first-class-citizen-jeff-reback.json
+++ b/pydata-new-york-city-2018/videos/pandas-integer-na-as-a-first-class-citizen-jeff-reback.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Jeff Reback"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/gxvTVxlvH9w/maxresdefault.jpg",
-  "title": "pandas: Integer NA as a first class citizen - Jeff Reback",
+  "title": "pandas: Integer NA as a first class citizen",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/repeatable-data-setup-for-repeatable-science-using-julia-sebastin-santy.json
+++ b/pydata-new-york-city-2018/videos/repeatable-data-setup-for-repeatable-science-using-julia-sebastin-santy.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Sebastin Santy"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/eMtuzjn_Xks/maxresdefault.jpg",
-  "title": "Repeatable Data Setup for Repeatable Science using Julia - Sebastin Santy",
+  "title": "Repeatable Data Setup for Repeatable Science using Julia",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/run-numba-functions-in-sqlite-wtf-phillip-cloud.json
+++ b/pydata-new-york-city-2018/videos/run-numba-functions-in-sqlite-wtf-phillip-cloud.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Phillip Cloud"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/PNvaDm8SKPs/maxresdefault.jpg",
-  "title": "Run Numba functions in SQLite: WTF? - Phillip Cloud",
+  "title": "Run Numba functions in SQLite: WTF?",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/scaling-interactive-pandas-workflows-with-modin-devin-petersohn.json
+++ b/pydata-new-york-city-2018/videos/scaling-interactive-pandas-workflows-with-modin-devin-petersohn.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Devin Petersohn"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/-HjLd_3ahCw/maxresdefault.jpg",
-  "title": "Scaling Interactive Pandas Workflows with Modin - Devin Petersohn",
+  "title": "Scaling Interactive Pandas Workflows with Modin",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/the-lifecycle-of-artificial-intelligence-with-ibm-s-deep-learning-as-a-service-justin-mccoy.json
+++ b/pydata-new-york-city-2018/videos/the-lifecycle-of-artificial-intelligence-with-ibm-s-deep-learning-as-a-service-justin-mccoy.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Justin McCoy"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/5Ms_kbDaBEI/maxresdefault.jpg",
-  "title": "The Lifecycle of Artificial Intelligence with IBM's Deep Learning as a Service - Justin McCoy",
+  "title": "The Lifecycle of Artificial Intelligence with IBM's Deep Learning as a Service",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/the-new-kid-on-the-block-deep-learning-with-gluonnlp-sneha-jha.json
+++ b/pydata-new-york-city-2018/videos/the-new-kid-on-the-block-deep-learning-with-gluonnlp-sneha-jha.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Sneha Jha"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/3FESBx6aZKA/maxresdefault.jpg",
-  "title": "The new kid on the block: deep learning with GluonNLP - Sneha Jha",
+  "title": "The new kid on the block: deep learning with GluonNLP",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/the-tiledb-array-data-storage-manager-stavros-papadopoulos-jake-bolewski.json
+++ b/pydata-new-york-city-2018/videos/the-tiledb-array-data-storage-manager-stavros-papadopoulos-jake-bolewski.json
@@ -10,10 +10,13 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Stavros Papadopoulos",
+    "Jake Bolewski"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/E2GRYw3yGw0/maxresdefault.jpg",
-  "title": "The TileDB Array Data Storage Manager - Stavros Papadopoulos, Jake Bolewski",
+  "title": "The TileDB Array Data Storage Manager",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/the-value-of-null-results-angel-d-az.json
+++ b/pydata-new-york-city-2018/videos/the-value-of-null-results-angel-d-az.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Angel D'az"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/yX-GKAiaVMQ/maxresdefault.jpg",
-  "title": "The Value of Null Results - Angel D'az",
+  "title": "The Value of Null Results",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/train-evaluate-repeat-building-a-credit-card-fraud-detection-system-leela-senthil-nathan.json
+++ b/pydata-new-york-city-2018/videos/train-evaluate-repeat-building-a-credit-card-fraud-detection-system-leela-senthil-nathan.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Leela Senthil Nathan"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/v8sQiKqQ_pw/maxresdefault.jpg",
-  "title": "Train, Evaluate, Repeat: Building a Credit Card Fraud Detection System - Leela Senthil Nathan",
+  "title": "Train, Evaluate, Repeat: Building a Credit Card Fraud Detection System",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/two-years-of-bayesian-bandits-for-e-commerce-austin-rochford.json
+++ b/pydata-new-york-city-2018/videos/two-years-of-bayesian-bandits-for-e-commerce-austin-rochford.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Austin Rochford"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/vupP9MYXeFM/maxresdefault.jpg",
-  "title": "Two Years of Bayesian Bandits for E Commerce - Austin Rochford",
+  "title": "Two Years of Bayesian Bandits for E Commerce",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/unit-testing-data-with-marbles-jane-stewart-adams-leif-walsh.json
+++ b/pydata-new-york-city-2018/videos/unit-testing-data-with-marbles-jane-stewart-adams-leif-walsh.json
@@ -10,10 +10,13 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Jane Stewart Adams",
+    "Leif Walsh"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/GwzkScTJTxI/maxresdefault.jpg",
-  "title": "Unit Testing Data with Marbles - Jane Stewart Adams, Leif Walsh",
+  "title": "Unit Testing Data with Marbles",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/unit-testing-for-data-scientists-hanna-torrence.json
+++ b/pydata-new-york-city-2018/videos/unit-testing-for-data-scientists-hanna-torrence.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Hanna Torrence"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/Da-FL_1i6ps/maxresdefault.jpg",
-  "title": "Unit Testing for Data Scientists - Hanna Torrence",
+  "title": "Unit Testing for Data Scientists",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/up-your-bus-number-a-reproducible-data-science-workflow-kjell-wooding-amy-wooding.json
+++ b/pydata-new-york-city-2018/videos/up-your-bus-number-a-reproducible-data-science-workflow-kjell-wooding-amy-wooding.json
@@ -10,10 +10,13 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Kjell Wooding",
+    "Amy Wooding"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/x7gukmVdAxw/maxresdefault.jpg",
-  "title": "Up your Bus Number - A Reproducible Data Science Workflow - Kjell Wooding, Amy Wooding",
+  "title": "Up your Bus Number - A Reproducible Data Science Workflow",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/using-embeddings-to-understand-the-variance-and-evolution-of-data-science-maryam-jahanshahi.json
+++ b/pydata-new-york-city-2018/videos/using-embeddings-to-understand-the-variance-and-evolution-of-data-science-maryam-jahanshahi.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Maryam Jahanshahi"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/lxtSHUa2FyA/maxresdefault.jpg",
-  "title": "Using Embeddings to Understand the Variance and Evolution of Data Science... - Maryam Jahanshahi",
+  "title": "Using Embeddings to Understand the Variance and Evolution of Data Science...",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/why-i-use-julia-for-quantum-physics-katharine-hyatt.json
+++ b/pydata-new-york-city-2018/videos/why-i-use-julia-for-quantum-physics-katharine-hyatt.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Katharine Hyatt"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/4giNd6HLUQg/maxresdefault.jpg",
-  "title": "Why I Use Julia For Quantum Physics - Katharine Hyatt",
+  "title": "Why I Use Julia For Quantum Physics",
   "videos": [
     {
       "type": "youtube",

--- a/pydata-new-york-city-2018/videos/you-are-not-a-computer-python-dynamical-systems-and-radical-embodied-henry-s-harrison.json
+++ b/pydata-new-york-city-2018/videos/you-are-not-a-computer-python-dynamical-systems-and-radical-embodied-henry-s-harrison.json
@@ -10,10 +10,12 @@
       "url": "https://pydata.org/nyc2018/schedule/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Henry S. Harrison"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/zhMwgIiCoko/maxresdefault.jpg",
-  "title": "You are not a Computer: Python, Dynamical Systems, and Radical Embodied... - Henry S. Harrison",
+  "title": "You are not a Computer: Python, Dynamical Systems, and Radical Embodied...",
   "videos": [
     {
       "type": "youtube",


### PR DESCRIPTION
The current version of the PyData NYC 2018 data has the speakers in the title. I have used a script to parse them out and update the video metadata.

I've also updated the metadata for my own talk at that conference, since I had the information handy.