### PR TITLE
Add missing talks from PyCon CA 2018

### DIFF
--- a/pycon-ca-2018/videos/gathering-related-functionality-paul-ganssle.json
+++ b/pycon-ca-2018/videos/gathering-related-functionality-paul-ganssle.json
@@ -1,0 +1,40 @@
+{
+  "copyright_text": "Creative Commons Attribution License (CC-BY)",
+  "description": "This talk will arm you with some tools to design a library that 'just works', but also has obvious escape hatches to handle corner cases. It covers several patterns for cleanly organizing related and overlapping functionality in a way that statisfies both humans and static analysis tools.\n\n---\n\nWhat do you do when you have to choose between designing your function for one of two common use cases?\n\nHow about when the same logical operations (say, multiplication or concatenation) need to have different implementations depending on the type of the arguments they are applied to?\n\nThese kinds of questions can be vexing when trying to design a clean, well-scoped API.\n\nThis talk will cover several strategies for grouping related functionality in a way that presents a logically clean interface to both humans and static analysis tools like type checkers and document generators.\n\nThis talk covers:\n\n- Alternate constructors with @classmethod\n- Inheritance with @staticmethod and @classmethod\n- Dispatch by type\n- A new convention for namespacing functions: variants\n",
+  "duration": 1809,
+  "language": "eng",
+  "recorded": "2018-11-11",
+  "relatd_urls": [
+    {
+      "label": "Author website",
+      "url": "https://ganssle.io"
+    },
+    {
+      "label": "Talk page",
+      "url": "https://2018.pycon.ca/talks/talk-PC-52797/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pganssle-talks.github.io/pycon-ca-2018-clean-apis"
+    },
+    {
+      "label": "Github Repository",
+      "url": "https://github.com/pganssle-talks/pycon-ca-2018-clean-apis"
+    }
+  ],
+  "speakers": [
+    "Paul Ganssle"
+  ],
+  "tags": [
+      "library",
+      "api design"
+  ],
+  "thumbnail_url": "http://i3.ytimg.com/vi/s8Rn188mNW4/hqdefault.jpg",
+  "title": "Gathering Related Functionality: Patterns for Clean API Design",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=s8Rn188mNW4"
+    }
+  ]
+}

--- a/pycon-ca-2018/videos/my-code-is-not-for-you-alina-matyukhina.json
+++ b/pycon-ca-2018/videos/my-code-is-not-for-you-alina-matyukhina.json
@@ -1,0 +1,26 @@
+{
+  "description": "OSS is open to anyone by design, whether it is developers or malicious users. Authors typically hide their identity through nicknames, however they have no protection against attribution techniques. This talk will present attacks on Python developers identity and discuss protection methods.\n\n---\n\nThe rapid increase in open source software is an attestation of a new standard in software development. Today over 80 percent of any software code is open source, according to a recent study by Sonatype. Python replaced Java as the second-most popular language on GitHub, with 40 percent more pull requests opened this year than last by GitHub Inc.'s annual report.\n\nAs the popularity of open source software increases, so do privacy concerns of individual contributors that often wish to remain anonymous. The majority of open-source repositories (GitHub, Google Code, SourceForge, etc.) allow users to keep their identity private while sharing their code. While in the past it was often sufficient, with the evolution of author attribution technology the question of how private the identity of software developers is becoming increasingly important.\n\nSoftware author attribution aims to decide who wrote a computer program, given its source or binary code. The main premise of this technique lies in the assumption that programmers unconsciously tend to use the same coding patterns. These patterns comprised of a number of distinctive features allow to characterise a programmer’s style and uniquely identify his/her works. Applications of software author attribution are wide and include software forensics - where the analyst wants to determine the author of a program given a set of potential programmers, plagiarism detection - where the analyst wants to identify illicit code reuse, ghostwriting detection - where given a suspicious piece of code the analysis wants to determine if it has been plagiarized from one of the programs in a given set, and in general any scenario where software ownership needs to be determined.\n\nIn this session we will show how analysts can identify the author of Python software and how this process can be deceiving. We present two attacks on current attribution systems: author imitation and author hiding. The first attack can be applied on Python developer's identity in open-source projects. The attack transforms syntactical representation of attacker’s source code to a version that mimics the victim’s coding style while retaining functionality of original code. This is particularly concerning for Python open-source contributors who are unaware of the fact that by contributing to open-source projects they reveal identifiable information that can be used to their disadvantage. For example, one can easily see that by imitating someone’s coding style it is possible to implicate any software developer in wrongdoing. To resist this attack we discuss multiple approaches of hiding a coding style of Python software author before contribute to open-source.",
+  "duration": 1705,
+  "recorded": "2018-11-11",
+  "relatd_urls": [
+    {
+      "label": "Talk page",
+      "url": "https://2018.pycon.ca/talks/talk-PC-55116/"
+    }
+  ],
+  "speakers": [
+    "Alina Matyukhina"
+  ],
+  "tags": [
+      "analytics",
+      "identity protection"
+  ],
+  "thumbnail_url": "http://i3.ytimg.com/vi/AMdZpDxrl6s/hqdefault.jpg",
+  "title": "My code is not for you: Protecting Python developer’s identity in OSS",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=AMdZpDxrl6s"
+    }
+  ]
+}

--- a/pycon-ca-2018/videos/open-sourcing-at-work-faisal-dosani.json
+++ b/pycon-ca-2018/videos/open-sourcing-at-work-faisal-dosani.json
@@ -1,0 +1,32 @@
+{
+  "description": "We just open sourced 2 projects (datacompy, and locopy) with roots in Data Science and Engineering which we will showcase. While is it exciting and rewarding to share your ideas with the world it isn't always easy. Thinking about licenses, copyrights, and protecting confidential information is a must!\n\nWorking in a large organization which is embracing the mantra 'open source first' is really exciting. Part of this journey is to make sure we give back to the open source community when we can. Two of our projects had gained traction internally: datacompy, and locopy. As part of our commitment we wanted to make sure we could open source these projects for others to use and contribute back to. DataComPy is a package to compare two Pandas DataFrames. Originally started to be something of a replacement for SAS's PROC COMPARE for Pandas DataFrames with some more functionality than just Pandas.DataFrame.equals(Pandas.DataFrame) (in that it prints out some stats, and lets you tweak how accurate matches have to be). Then extended to carry that functionality over to Spark Dataframes. Locopy helps load flat files to S3 and then to Amazon Redshift, and assist with ETL processing. It is DB Driver (Adapter) agnostic, provides basic functionality to move data to S3 buckets, execute COPY commands to load data to S3, and into Redshift, and UNLOAD commands to unload data from Redshift into S3. While building these products was exciting and fun, some of the legal considerations were as interesting, complex, and required collaboration between many teams, from security, licensing, brand, and IP/copyright. We'll explore the projects, and some of these other considerations which can make or break if you decide to release a project into the wild, along with the road blocks we faced with in these areas.",
+  "duration": 731,
+  "recorded": "2018-11-11",
+  "relatd_urls": [
+    {
+      "label": "Talk page",
+      "url": "https://2018.pycon.ca/talks/talk-PC-53138/"
+    }
+  ],
+  "speakers": [
+    "Faisal Dosani"
+  ],
+  "tags": [
+      "open source",
+      "licensing",
+      "copyright",
+      "data",
+      "security",
+      "testing",
+      "best practices",
+      "data science"
+  ],
+  "thumbnail_url": "http://i3.ytimg.com/vi/IDdlyw6Dn-Y/hqdefault.jpg",
+  "title": "Open Sourcing at Work",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=IDdlyw6Dn-Y"
+    }
+  ]
+}

--- a/pycon-ca-2018/videos/the-journey-from-mediocrity-victoria-mothersill.json
+++ b/pycon-ca-2018/videos/the-journey-from-mediocrity-victoria-mothersill.json
@@ -1,0 +1,26 @@
+{
+  "description": "You read the docs, you did the learn to code exercises, you spent time in production. How do you know when you’re good at this? We’re programmers, so let’s break it up into parts. Let’s look at how we see ourselves, how our code performs, and how others see our code. Okay, now add, commit, push.\n\nIntro (1 minute):\n\nThe python community is filled with many people from many disciplines that learned python for all kinds of different reasons. Not all of us took computer science in university, not all of us learned to code when we were 8.\n\nI work in post-production for film, I’ve been writing python every day at my job for two years now. When I started I was pretty rusty. I’d taken a few courses in university, but hadn’t written anything substantive for a couple of years. Getting good creeps up slowly. Your first day on the job you’re not good, your second day, your third. But I look at myself now and I’m writing full stack plugins. How did I get here? Am I good yet? How many grains of sand make a heap?\n\nThe Aha moments, from veteran pythonistas (3 minutes):\n\nFeaturing quotes from my interviews with veteran coders:\n\nTell me a story about when you sucked.\nWhat was the moment you knew you were getting kinda good at this thing?\nWhat do you look for in others when gaging their python competence?\nThe answers to these three questions will frame the rest of the talk. Question 1: talks about how you see yourself. Coding is hard and we all start out sucking, we keep seeing ourselves as beginner programmers long after our skills outstripe this. Question 2: how our code actually performs. When does your curiosity/excitement get stronger than your fear or uncertainty, when do you start seeing efficiencies outside the scope of what your instructed to do. Question 3: how others see your code. Make your code reader friendly and your code reviews will be nicer, your coffee will taste sweeter, your coworkers will stop hissing when they see you. Do future you a solid.\n\nHow you see yourself (1 minute):\n\nWorking with your impostor syndrome\n\nSome of it’s in your head, some of it isn’t\nMake smart friends. If you’re the smartest person in the room, you’re doing something wrong.\nEmbrace feeling dumb. Being wrong now is an opportunity to be right later. * Be wrong early, be wrong often, learn from mistakes.\nThe psychologist Carol Dweck talks about something called growth mindset. Don’t be smart, do smart. Look for opportunities to grow yourself rather than being ego protective about your coding skills\nHow your code performs (2 minutes)\n\nAutomate your little tasks! Then automate more! (this will include a short example from production)\nWrite your own mandate! If something isn’t strictly in your job description, but it will make your life easier, your team’s life easier? Well just write that sucker. Psychologist Amy Wrzesniewski writes about how individuals with higher job satisfaction engage in what she calls “job crafting”.\nHow others see your code (3 minutes):\n\nthree habits for leveling up, each of these will have short examples\n\nWrite documentation!\n\nDocstrings and descriptive variables. When you come back to something you wrote a year ago you’re going to be happy your variables aren’t called: var1, var2, var3.\nUse sphinx to auto-create documentation out of your docstrings! Get in the habit of this and you’ll feel like a wizard!\nTesting! * I’ll have a short example using PyTest\n\nPep-8!\n\nSure, formatting isn’t the sexiest part of coding, but when you look back at your clean, pretty code, it can make you feel polished in a way nothing else can. Also, I mean, other people can read your work and stuff…\n",
+  "duration": 607,
+  "recorded": "2018-11-11",
+  "relatd_urls": [
+    {
+      "label": "Talk page",
+      "url": "https://2018.pycon.ca/talks/talk-PC-55513/"
+    },
+    {
+      "label": "Author website",
+      "url": "https://www.imdb.com/name/nm6099613/"
+    }
+  ],
+  "speakers": [
+    "Victoria Mothersill"
+  ],
+  "thumbnail_url": "http://i3.ytimg.com/vi/krGwiTCPo4g/hqdefault.jpg",
+  "title": "The Journey from Mediocrity: How to Stop Feeling Like a Beginner",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=krGwiTCPo4g"
+    }
+  ]
+}

--- a/pycon-ca-2018/videos/what-a-bug-can-teach-you-brad-dettmer.json
+++ b/pycon-ca-2018/videos/what-a-bug-can-teach-you-brad-dettmer.json
@@ -1,0 +1,26 @@
+{
+  "description": "We’ll take a look at some Python code that has a strange bug in it. You’ll learn why it’s a bug and why it only occurs with larger numbers. We’ll cover fixes, dive into how Python works and look at some CPython source code. You’ll learn about “is” vs “==” and how to prevent bugs.\n\nWe’ll take a look at some Python code that has a strange integer bug in it. You’ll learn about how the bug was discovered, and by the end of the talk you’ll understand why it’s a bug and why the bug only occurs with larger integers. You’ll see a one character fix to the bug, and then an even better fix. We’ll look at CPython's longobject.c source code to understand how smaller integers are handled differently than larger ones. We’ll explore the difference between comparing values in Python versus testing for identity. Hopefully you’ll gain an appreciation that bugs can be your best teachers and be able to prevent more bugs.",
+  "duration": 779,
+  "recorded": "2018-11-11",
+  "relatd_urls": [
+    {
+      "label": "Talk page",
+      "url": "https://2018.pycon.ca/talks/talk-PC-55513/"
+    }
+  ],
+  "speakers": [
+    "Brad Dettmer"
+  ],
+  "tags": [
+      "cpython",
+      "debugging"
+  ],
+  "thumbnail_url": "http://i3.ytimg.com/vi/N7J8fmPmSjQ/hqdefault.jpg",
+  "title": "What a Bug can Teach You about Python",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=N7J8fmPmSjQ"
+    }
+  ]
+}


### PR DESCRIPTION
Added a few missing talks from PyCon CA 2018 (these were uploaded a few months after the others).