### PR TITLE
Add lightning talk speakers for PyCon 2018 Sun AM

### DIFF
--- a/pycon-us-2018/videos/sunday-morning-lightning-talks-keynote-pycon-2018.json
+++ b/pycon-us-2018/videos/sunday-morning-lightning-talks-keynote-pycon-2018.json
@@ -19,7 +19,13 @@
     }
   ],
   "speakers": [
-    "Brett Cannon"
+    "Brett Cannon",
+    "Tim Abbott",
+    "Jonathan Slenders",
+    "Mark Shields",
+    "Paul Ganssle",
+    "Michael Sullivan",
+    "Moshe Zadka"
   ],
   "tags": [
     "keynote",


### PR DESCRIPTION
The video for the PyCon US 2018 Sunday Morning lighting talks is included in the video for Brett Cannon's keynote. This commit adds the lightning talk speakers to the video data.