### PR TITLE
python-frederick: Manually review

### DIFF
--- a/python-frederick/category.json
+++ b/python-frederick/category.json
@@ -1,4 +1,4 @@
 {
-  "title": "Python Frederick",
-  "description": "Python user group Meetup in Frederick, MD"
+  "description": "Python user group Meetup in Frederick, MD",
+  "title": "Python Frederick"
 }

--- a/python-frederick/videos/anvil-at-python-frederick.json
+++ b/python-frederick/videos/anvil-at-python-frederick.json
@@ -2,13 +2,25 @@
   "description": "Meredydd gave a talk about Anvil to Python Frederick, a Python user group in Frederick, MD. Thanks for joining us!",
   "language": "eng",
   "recorded": "2019-01-09",
-  "speakers": ["Meredydd Luff"],
-  "thumbnail_url": "https://i.ytimg.com/vi/rUVBp-rXwEA/hqdefault.jpg",
-  "tags": [
-      "anvil",
-      "webapp"
+  "related_urls": [
+    {
+      "label": "Anvil",
+      "url": "https://anvil.works/"
+    },
+    {
+      "label": "Python Frederick web",
+      "url": "https://www.pythonfrederick.org/"
+    }
   ],
-  "title": "Anvil at Python Frederick",
+  "speakers": [
+    "Meredydd Luff"
+  ],
+  "tags": [
+    "anvil",
+    "webapp"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/rUVBp-rXwEA/hqdefault.jpg",
+  "title": "Anvil",
   "videos": [
     {
       "type": "youtube",

--- a/python-frederick/videos/build-native-mobile-apps-with-python-and-beeware-python-frederick.json
+++ b/python-frederick/videos/build-native-mobile-apps-with-python-and-beeware-python-frederick.json
@@ -2,13 +2,21 @@
   "description": "At the October 2018 Python Frederick event, Bob showed the group how we can build native mobile applications that are written completely in Python using the BeeWare suite of tools",
   "language": "eng",
   "recorded": "2018-10-11",
-  "speakers": ["Bob Marchese"],
-  "thumbnail_url": "https://i.ytimg.com/vi/tyh165h_PhU/hqdefault.jpg",
-  "tags": [
-      "beeware",
-      "mobile"
+  "related_urls": [
+    {
+      "label": "Python Frederick web",
+      "url": "https://www.pythonfrederick.org/\n"
+    }
   ],
-  "title": "Build Native Mobile Apps with Python and BeeWare (Python Frederick)",
+  "speakers": [
+    "Bob Marchese"
+  ],
+  "tags": [
+    "beeware",
+    "mobile"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/tyh165h_PhU/hqdefault.jpg",
+  "title": "Build Native Mobile Apps with Python and BeeWare",
   "videos": [
     {
       "type": "youtube",

--- a/python-frederick/videos/data-science-in-python-python-frederick.json
+++ b/python-frederick/videos/data-science-in-python-python-frederick.json
@@ -1,13 +1,25 @@
 {
-  "description": "At the December 2017 Python Frederick meetup, Christine Lee provided an excellent overview of the Python data science ecosystem. There's a lot of info so the topics are listed below with their times.\n\nAnaconda - https://youtu.be/3kTOLVD0ZCg?t=236\nNumPy - https://youtu.be/3kTOLVD0ZCg?t=726\nSymPy - https://youtu.be/3kTOLVD0ZCg?t=1204\nSciPy - https://youtu.be/3kTOLVD0ZCg?t=1827\nscikit-learn - https://youtu.be/3kTOLVD0ZCg?t=2432\npandas - https://youtu.be/3kTOLVD0ZCg?t=3385\nmatplotlib - https://youtu.be/3kTOLVD0ZCg?t=3953\nBokey and Plotly - https://youtu.be/3kTOLVD0ZCg?t=4458\nJupyter Notebooks - https://youtu.be/3kTOLVD0ZCg?t=5520\n\nhttps://www.pythonfrederick.org/\n\nTalk material can be found at https://github.com/python-frederick/talks/tree/master/2017-12-data-science.",
+  "description": "At the December 2017 Python Frederick meetup, Christine Lee provided an excellent overview of the Python data science ecosystem. There's a lot of info so the topics are listed below with their times.\n\n* Anaconda - https://youtu.be/3kTOLVD0ZCg?t=236\n* NumPy - https://youtu.be/3kTOLVD0ZCg?t=726\n* SymPy - https://youtu.be/3kTOLVD0ZCg?t=1204\n* SciPy - https://youtu.be/3kTOLVD0ZCg?t=1827\n* scikit-learn - https://youtu.be/3kTOLVD0ZCg?t=2432\n* pandas - https://youtu.be/3kTOLVD0ZCg?t=3385\n* matplotlib - https://youtu.be/3kTOLVD0ZCg?t=3953\n* Bokey and Plotly - https://youtu.be/3kTOLVD0ZCg?t=4458\n* Jupyter Notebooks - https://youtu.be/3kTOLVD0ZCg?t=5520",
   "language": "eng",
   "recorded": "2017-12-14",
-  "speakers": ["Christine Lee"],
+  "related_urls": [
+    {
+      "label": "Talk repository",
+      "url": "https://github.com/python-frederick/talks/tree/master/2017-12-data-science"
+    },
+    {
+      "label": "Python Frederick web",
+      "url": "https://www.pythonfrederick.org/"
+    }
+  ],
+  "speakers": [
+    "Christine Lee"
+  ],
   "tags": [
-      "data science"
+    "data science"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/3kTOLVD0ZCg/hqdefault.jpg",
-  "title": "Data science in Python (Python Frederick)",
+  "title": "Data science in Python",
   "videos": [
     {
       "type": "youtube",

--- a/python-frederick/videos/django-tutorial-adventure-part-2.json
+++ b/python-frederick/videos/django-tutorial-adventure-part-2.json
@@ -1,11 +1,23 @@
 {
-  "description": "At the December 2018 Python Frederick event, Patrick walked through the second half of the Django 2.1 tutorial. Since Patrick is a DevOps engineer instead of a web developer, the group got to share in the experience in a novice.\n\nThe Django tutorial is very large so we picked up from where we left off from the previous presentation. If you want to watch that experience, check out https://www.youtube.com/watch?v=ZSs2eZ-yFps&index=2&list=PLFcKEo4b_n1wMFhbiedpMgh2VRT5uICuF.\n\nPython Frederick is the Python user group in Frederick, MD. You can learn more about the group at https://www.pythonfrederick.org/.",
+  "description": "At the December 2018 Python Frederick event, Patrick walked through the second half of the Django 2.1 tutorial. Since Patrick is a DevOps engineer instead of a web developer, the group got to share in the experience in a novice.\n\nThe Django tutorial is very large so we picked up from where we left off from the previous presentation. If you want to watch that experience, check out https://www.youtube.com/watch?v=ZSs2eZ-yFps",
   "language": "eng",
   "recorded": "2018-12-13",
-  "speakers": ["Patrick Pierson"],
+  "related_urls": [
+    {
+      "label": "Django Tutorial Adventure Part 1",
+      "url": "https://www.youtube.com/watch?v=ZSs2eZ-yFps"
+    },
+    {
+      "label": "Python Frederick web",
+      "url": "https://www.pythonfrederick.org/"
+    }
+  ],
+  "speakers": [
+    "Patrick Pierson"
+  ],
   "tags": [
-      "django",
-      "web development"
+    "django",
+    "web development"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/R733F2emni4/hqdefault.jpg",
   "title": "Django Tutorial Adventure Part 2",

--- a/python-frederick/videos/django-tutorial-adventure.json
+++ b/python-frederick/videos/django-tutorial-adventure.json
@@ -2,10 +2,22 @@
   "description": "At the August 2018 Python Frederick event, Patrick walked through the Django 2.1 tutorial. Since Patrick is a DevOps engineer instead of a web developer, the group got to share in the experience in a novice.\n\nThe Django tutorial is very large so we only managed to complete parts 1 and 2 of the tutorial.",
   "language": "eng",
   "recorded": "2018-08-09",
-  "speakers": ["Patrick Pierson"],
+  "related_urls": [
+    {
+      "label": "Django Tutorial Adventure Part 2",
+      "url": "https://www.youtube.com/watch?v=R733F2emni4"
+    },
+    {
+      "label": "Python Frederick web",
+      "url": "https://www.pythonfrederick.org/"
+    }
+  ],
+  "speakers": [
+    "Patrick Pierson"
+  ],
   "tags": [
-      "django",
-      "web development"
+    "django",
+    "web development"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/ZSs2eZ-yFps/hqdefault.jpg",
   "title": "Django Tutorial Adventure",

--- a/python-frederick/videos/how-we-built-pythonfrederickorg-for-4c-a-day-python-frederick.json
+++ b/python-frederick/videos/how-we-built-pythonfrederickorg-for-4c-a-day-python-frederick.json
@@ -2,13 +2,29 @@
   "description": "At our March 2018 event, Matt Layman spoke to the group about how to build a portfolio website using Pelican and Netlify for the cost of a domain name.\n\nThe recording was interrupted when a display cable was pulled, but the first portion of the talk outlines most of the parts and process are included so we decided to publish it anyway.\n\nNote: requirement.txt should have been requirements.txt (with an s character). This was an oversight and fixed later in the talk.",
   "language": "eng",
   "recorded": "2018-03-14",
-  "speakers": ["Matt Layman"],
+  "related_urls": [
+    {
+      "label": "Python Frederick web",
+      "url": "https://www.pythonfrederick.org/\n"
+    },
+    {
+      "label": "Speaker web (most popular articles)",
+      "url": "https://www.mattlayman.com/most-popular/"
+    },
+    {
+      "label": "Speaker web (newsletter)",
+      "url": "https://www.mattlayman.com/newsletter/"
+    }
+  ],
+  "speakers": [
+    "Matt Layman"
+  ],
   "tags": [
-      "Netlify",
-      "Pelican"
+    "netlify",
+    "pelican"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/1wGQeNWQBvY/hqdefault.jpg",
-  "title": "How we built pythonfrederick.org for 4\u00a2 a day (Python Frederick)",
+  "title": "How we built pythonfrederick.org for 4\u00a2 a day",
   "videos": [
     {
       "type": "youtube",

--- a/python-frederick/videos/pipfile-and-pipenv-python-frederick.json
+++ b/python-frederick/videos/pipfile-and-pipenv-python-frederick.json
@@ -1,14 +1,34 @@
 {
-  "description": "At this Python Frederick talk, Matt Layman talked about Python's new Pipfile format and how it solves some of the package dependency management problems that Python applications face.\n\nhttps://github.com/python-frederick/talks/tree/master/2017-08-pipfile\n\nhttps://www.pythonfrederick.org/",
+  "description": "At this Python Frederick talk, Matt Layman talked about Python's new Pipfile format and how it solves some of the package dependency management problems that Python applications face.",
   "language": "eng",
   "recorded": "2017-08-09",
-  "speakers": ["Matt Layman"],
+  "related_urls": [
+    {
+      "label": "Talk slides repository",
+      "url": "https://github.com/python-frederick/talks/tree/master/2017-08-pipfile"
+    },
+    {
+      "label": "Python Frederick web",
+      "url": "https://www.pythonfrederick.org/"
+    },
+    {
+      "label": "Speaker web (most popular articles)",
+      "url": "https://www.mattlayman.com/most-popular/"
+    },
+    {
+      "label": "Speaker web (newsletter)",
+      "url": "https://www.mattlayman.com/newsletter/"
+    }
+  ],
+  "speakers": [
+    "Matt Layman"
+  ],
   "tags": [
-      "Pipfile",
-      "pipenv"
+    "pipfile",
+    "pipenv"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/rR8F_Uaf9_I/hqdefault.jpg",
-  "title": "Pipfile and pipenv (Python Frederick)",
+  "title": "Pipfile and pipenv",
   "videos": [
     {
       "type": "youtube",

--- a/python-frederick/videos/python-software-defined-radios-python-frederick.json
+++ b/python-frederick/videos/python-software-defined-radios-python-frederick.json
@@ -1,13 +1,25 @@
 {
-  "description": "At the April 2018 Python Frederick presentation, Patrick Pierson talked about how to use Python with software defined radios.\n\nTalk material: https://github.com/python-frederick/talks/tree/master/2018-04-software-defined-radio\n\nhttps://www.pythonfrederick.org/",
+  "description": "At the April 2018 Python Frederick presentation, Patrick Pierson talked about how to use Python with software defined radios.",
   "language": "eng",
   "recorded": "2018-04-13",
-  "speakers": ["Patrick Pierson"],
+  "related_urls": [
+    {
+      "label": "Talk repository",
+      "url": "https://github.com/python-frederick/talks/tree/master/2018-04-software-defined-radio"
+    },
+    {
+      "label": "Python Frederick web",
+      "url": "https://www.pythonfrederick.org/"
+    }
+  ],
+  "speakers": [
+    "Patrick Pierson"
+  ],
   "tags": [
-      "SDR"
+    "sdr"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/MonR5zZL-Es/hqdefault.jpg",
-  "title": "Python + Software Defined Radios (Python Frederick)",
+  "title": "Python + Software Defined Radios",
   "videos": [
     {
       "type": "youtube",

--- a/python-frederick/videos/python-testing-101-with-pytest.json
+++ b/python-frederick/videos/python-testing-101-with-pytest.json
@@ -1,12 +1,32 @@
 {
-  "description": "At the March 2019 Python Frederick event, Matt focused on the fundamentals of Python testing while using the pytest package.\n\nThe code for tonight's presentation is available to review on GitHub at https://github.com/python-frederick/python-testing-101.\n\nPython Frederick is the Python user group in Frederick, MD. You can learn more about the group at https://www.pythonfrederick.org/.\n\nWant to learn more? You can check out my most popular articles at https://www.mattlayman.com/most-popular/. \n\nI also have a newsletter where I share articles about #Python and other software topics. Join in at https://www.mattlayman.com/newsletter/.",
+  "description": "At the March 2019 Python Frederick event, Matt focused on the fundamentals of Python testing while using the pytest package.",
   "language": "eng",
   "recorded": "2019-03-13",
-  "speakers": ["Matt Layman"],
+  "related_urls": [
+    {
+      "label": "Talk repository",
+      "url": "https://github.com/python-frederick/python-testing-101"
+    },
+    {
+      "label": "Python Frederick web",
+      "url": "https://www.pythonfrederick.org/"
+    },
+    {
+      "label": "Speaker web (most popular articles)",
+      "url": "https://www.mattlayman.com/most-popular/"
+    },
+    {
+      "label": "Speaker web (newsletter)",
+      "url": "https://www.mattlayman.com/newsletter/"
+    }
+  ],
+  "speakers": [
+    "Matt Layman"
+  ],
   "tags": [
-      "pytest",
-      "unit testing",
-      "testing"
+    "pytest",
+    "unit testing",
+    "testing"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/etosV2IWBF0/hqdefault.jpg",
   "title": "Python Testing 101 with pytest",

--- a/python-frederick/videos/python-testing-201-with-pytest.json
+++ b/python-frederick/videos/python-testing-201-with-pytest.json
@@ -1,14 +1,30 @@
 {
-  "description": "At the September 2019 Python Frederick event, Matt explored the features of pytest and how to apply them to Python.\n\nPython Frederick is the Python user group in Frederick, MD. You can learn more about the group at https://www.pythonfrederick.org/.",
+  "description": "At the September 2019 Python Frederick event, Matt explored the features of pytest and how to apply them to Python.",
   "language": "eng",
   "recorded": "2019-09-11",
-  "speakers": ["Matt Layman"],
-  "thumbnail_url": "https://i.ytimg.com/vi/fv259R38gqc/hqdefault.jpg",
-  "tags": [
-      "pytest",
-      "unit testing",
-      "testing"
+  "related_urls": [
+    {
+      "label": "Python Frederick web",
+      "url": "https://www.pythonfrederick.org/\n"
+    },
+    {
+      "label": "Speaker web (most popular articles)",
+      "url": "https://www.mattlayman.com/most-popular/"
+    },
+    {
+      "label": "Speaker web (newsletter)",
+      "url": "https://www.mattlayman.com/newsletter/"
+    }
   ],
+  "speakers": [
+    "Matt Layman"
+  ],
+  "tags": [
+    "pytest",
+    "unit testing",
+    "testing"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/fv259R38gqc/hqdefault.jpg",
   "title": "Python Testing 201 with pytest",
   "videos": [
     {

--- a/python-frederick/videos/python-web-frameworks-shootout-python-frederick.json
+++ b/python-frederick/videos/python-web-frameworks-shootout-python-frederick.json
@@ -1,17 +1,37 @@
 {
-  "description": "At the October 2017 Python Frederick meetup, we looked at API Star, Falcon, Flask, Django, and Pyramid and did a comparison of their features to see which would be the best fit for your future web project.\n\nhttps://github.com/mblayman/web-framework-shootout\n\nhttps://www.pythonfrederick.org/",
+  "description": "At the October 2017 Python Frederick meetup, we looked at API Star, Falcon, Flask, Django, and Pyramid and did a comparison of their features to see which would be the best fit for your future web project.",
   "language": "eng",
   "recorded": "2017-10-11",
-  "speakers": ["Matt Layman"],
+  "related_urls": [
+    {
+      "label": "Talk repository",
+      "url": "https://github.com/mblayman/web-framework-shootout"
+    },
+    {
+      "label": "Python Frederick web",
+      "url": "https://www.pythonfrederick.org/"
+    },
+    {
+      "label": "Speaker web (most popular articles)",
+      "url": "https://www.mattlayman.com/most-popular/"
+    },
+    {
+      "label": "Speaker web (newsletter)",
+      "url": "https://www.mattlayman.com/newsletter/"
+    }
+  ],
+  "speakers": [
+    "Matt Layman"
+  ],
   "tags": [
-      "API Star",
-      "Falcon",
-      "Flask",
-      "Django",
-      "Pyramid"
+    "api star",
+    "falcon",
+    "flask",
+    "django",
+    "pyramid"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/Pu_5ZjC7Tig/hqdefault.jpg",
-  "title": "Python web frameworks shootout (Python Frederick)",
+  "title": "Python web frameworks shootout",
   "videos": [
     {
       "type": "youtube",

--- a/python-frederick/videos/scaping-the-web-with-scrapy-python-frederick.json
+++ b/python-frederick/videos/scaping-the-web-with-scrapy-python-frederick.json
@@ -1,14 +1,26 @@
 {
-  "description": "At the November 2017 Python Frederick presentation, Micah showed the group how to get data from web pages using Scrapy. He explained the core pieces needed to work with Scrapy and demonstrated the tool by building a project that scraped content from a sample website.\n\nSlides can be found at: http://lucy.rehack.me/slides/scrapy/\n\nhttps://www.pythonfrederick.org/",
+  "description": "At the November 2017 Python Frederick presentation, Micah showed the group how to get data from web pages using Scrapy. He explained the core pieces needed to work with Scrapy and demonstrated the tool by building a project that scraped content from a sample website.",
   "language": "eng",
   "recorded": "2017-11-09",
-  "speakers": ["Micah Nordland"],
+  "related_urls": [
+    {
+      "label": "Talk slides",
+      "url": "http://lucy.rehack.me/slides/scrapy/"
+    },
+    {
+      "label": "Python Frederick web",
+      "url": "https://www.pythonfrederick.org/"
+    }
+  ],
+  "speakers": [
+    "Micah Nordland"
+  ],
   "tags": [
-      "Scrapy",
-      "scraping"
+    "scrapy",
+    "scraping"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/tdA1cl6LiCw/hqdefault.jpg",
-  "title": "Scaping the web with Scrapy (Python Frederick)",
+  "title": "Scaping the web with Scrapy",
   "videos": [
     {
       "type": "youtube",

--- a/python-frederick/videos/using-git-and-github-to-safely-store-your-code.json
+++ b/python-frederick/videos/using-git-and-github-to-safely-store-your-code.json
@@ -1,11 +1,27 @@
 {
-  "description": "At Python Frederick for July 2019, I presented on the fundamentals of #Git and #GitHub for storing your code safely and sharing it with others. This talk is aimed at beginners with no prior knowledge of Git.\n\nPython Frederick is the Python user group in Frederick, MD. You can learn more about the group at https://www.pythonfrederick.org/.\n\nWant to learn more? You can check out my most popular articles at https://www.mattlayman.com/most-popular/. \n\nI also have a newsletter where I share articles about #Python, Django, SaaS, and other software topics. Join in at https://www.mattlayman.com/newsletter/.",
+  "description": "At Python Frederick for July 2019, I presented on the fundamentals of #Git and #GitHub for storing your code safely and sharing it with others. This talk is aimed at beginners with no prior knowledge of Git.",
   "language": "eng",
   "recorded": "2019-07-10",
-  "speakers": ["Matt Layman"],
+  "related_urls": [
+    {
+      "label": "Python Frederick web",
+      "url": "https://www.pythonfrederick.org/"
+    },
+    {
+      "label": "Speaker web (most popular articles)",
+      "url": "https://www.mattlayman.com/most-popular/"
+    },
+    {
+      "label": "Speaker web (newsletter)",
+      "url": "https://www.mattlayman.com/newsletter/"
+    }
+  ],
+  "speakers": [
+    "Matt Layman"
+  ],
   "tags": [
-      "Git",
-      "GitHub"
+    "git",
+    "github"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/v98_7iHlYWM/hqdefault.jpg",
   "title": "Using Git and GitHub to safely store your code",


### PR DESCRIPTION
Reviewed and edited with [pyvideo_lektor](https://github.com/pyvideo/pyvideo_lektor).

@mblayman, This is a review by example (just to not to annoy you from the start with pyvideo style).

* [`tags`](https://pyvideo.org/tags.html): lower case to try to avoid duplicates.
* `title`: Only the title here (No author, date, name of the conference/user group, etc)
* `description`: Only the description of the talk in restructured text (No generic references to the conference/user group)
* `related_urls`: Add here urls to talk materials (slides, repos), all urls in the description and all conference/user group relevant urls.

Json format (indentation). solved with `reserialize` (or `pyvideo_lektor` if you edit it):
~~~ bash
python tools/reserialize.py --all .
~~~

For a quick publish you can defer all this using the `minimal_download: true` option in  [pyvideo_scrape](https://github.com/pyvideo/pyvideo_scrape).