### PR TITLE
PyGotham 2019: Add lightning talk speakers

### DIFF
--- a/pygotham-2019/videos/the-ministry-of-silly-talks.json
+++ b/pygotham-2019/videos/the-ministry-of-silly-talks.json
@@ -5,9 +5,20 @@
   "language": "eng",
   "recorded": "2019-10-04",
   "related_urls": [],
-  "speakers": [],
+  "speakers": [
+    "Aditya Sirish",
+    "Paul Ganssle",
+    "Thomas J Fan",
+    "Kat Hartling",
+    "Julian Berman",
+    "Timothy Allen",
+    "Anuj Menta",
+    "Jonathan Meier",
+    "Mahmoud Hashemi",
+    "Dustin Ingram"
+  ],
   "tags": [],
-	"thumbnail_url": "https://i.ytimg.com/vi/YmAXhlcNbys/maxresdefault.jpg",
+  "thumbnail_url": "https://i.ytimg.com/vi/YmAXhlcNbys/maxresdefault.jpg",
   "title": "The Ministry of Silly Talks",
   "videos": [
     {


### PR DESCRIPTION
(And replace a tab with two spaces)