### PR TITLE
Few fixes for PyCon Belarus 2018: language, speakers list

### DIFF
--- a/pycon-belarus-2018/videos/aleksandr-koshelev-iandeks-buferizatsiia-zapisi-v-bazu.json
+++ b/pycon-belarus-2018/videos/aleksandr-koshelev-iandeks-buferizatsiia-zapisi-v-bazu.json
@@ -2,7 +2,7 @@
   "copyright_text": null,
   "description": "",
   "duration": 2243,
-  "language": "eng",
+  "language": "rus",
   "recorded": "2018-02-24",
   "related_urls": [
     {
@@ -10,10 +10,13 @@
       "url": "https://web.archive.org/web/20180720115405/https://by.pycon.org/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Alexander Koshelev",
+    "\u0410\u043b\u0435\u043a\u0441\u0430\u043d\u0434\u0440 \u041a\u043e\u0448\u0435\u043b\u0435\u0432"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/TDtzsD0HKCo/maxresdefault.jpg",
-  "title": "\u0410\u043b\u0435\u043a\u0441\u0430\u043d\u0434\u0440 \u041a\u043e\u0448\u0435\u043b\u0435\u0432, \u042f\u043d\u0434\u0435\u043a\u0441 - \u0411\u0443\u0444\u0435\u0440\u0438\u0437\u0430\u0446\u0438\u044f \u0437\u0430\u043f\u0438\u0441\u0438 \u0432 \u0431\u0430\u0437\u0443",
+  "title": "\u0411\u0443\u0444\u0435\u0440\u0438\u0437\u0430\u0446\u0438\u044f \u0437\u0430\u043f\u0438\u0441\u0438 \u0432 \u0431\u0430\u0437\u0443",
   "videos": [
     {
       "type": "youtube",

--- a/pycon-belarus-2018/videos/andrew-svetlov-advanced-unicode.json
+++ b/pycon-belarus-2018/videos/andrew-svetlov-advanced-unicode.json
@@ -2,7 +2,7 @@
   "copyright_text": null,
   "description": "",
   "duration": 2886,
-  "language": "eng",
+  "language": "rus",
   "recorded": "2018-02-24",
   "related_urls": [
     {
@@ -10,10 +10,12 @@
       "url": "https://web.archive.org/web/20180720115405/https://by.pycon.org/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Andrew Svetlov"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/rzey5swy2bg/maxresdefault.jpg",
-  "title": "Andrew Svetlov - Advanced Unicode",
+  "title": "Advanced Unicode",
   "videos": [
     {
       "type": "youtube",

--- a/pycon-belarus-2018/videos/andrey-vlasovskikh-jetbrains-what-python-can-do-with-microcontrollers.json
+++ b/pycon-belarus-2018/videos/andrey-vlasovskikh-jetbrains-what-python-can-do-with-microcontrollers.json
@@ -2,7 +2,7 @@
   "copyright_text": null,
   "description": "",
   "duration": 2459,
-  "language": "eng",
+  "language": "rus",
   "recorded": "2018-02-24",
   "related_urls": [
     {
@@ -10,10 +10,12 @@
       "url": "https://web.archive.org/web/20180720115405/https://by.pycon.org/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Andrey Vlasovskikh"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/0KMnJm3kRSQ/maxresdefault.jpg",
-  "title": "Andrey Vlasovskikh, JetBrains - What Python Can Do with Microcontrollers",
+  "title": "What Python Can Do with Microcontrollers",
   "videos": [
     {
       "type": "youtube",

--- a/pycon-belarus-2018/videos/andrii-soldatenko-tippilab-ethereum-under-the-microscope.json
+++ b/pycon-belarus-2018/videos/andrii-soldatenko-tippilab-ethereum-under-the-microscope.json
@@ -10,10 +10,12 @@
       "url": "https://web.archive.org/web/20180720115405/https://by.pycon.org/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Andrii Soldatenko"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/UOINztxa4PU/maxresdefault.jpg",
-  "title": "Andrii Soldatenko, Tippilab - Ethereum Under the Microscope",
+  "title": "Ethereum Under the Microscope",
   "videos": [
     {
       "type": "youtube",

--- a/pycon-belarus-2018/videos/gael-varoquaux-inria-from-numerics-to-data-science-in-python.json
+++ b/pycon-belarus-2018/videos/gael-varoquaux-inria-from-numerics-to-data-science-in-python.json
@@ -10,10 +10,12 @@
       "url": "https://web.archive.org/web/20180720115405/https://by.pycon.org/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Gael Varoquaux"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/b9lracHGoio/maxresdefault.jpg",
-  "title": "Gael Varoquaux, INRIA - From numerics to data science in Python",
+  "title": "From numerics to data science in Python",
   "videos": [
     {
       "type": "youtube",

--- a/pycon-belarus-2018/videos/grigorii-bakunov-iandeks-igrat-s-ii-s-chego-nachat-i-chem-prodolzhit.json
+++ b/pycon-belarus-2018/videos/grigorii-bakunov-iandeks-igrat-s-ii-s-chego-nachat-i-chem-prodolzhit.json
@@ -2,7 +2,7 @@
   "copyright_text": null,
   "description": "",
   "duration": 3764,
-  "language": "eng",
+  "language": "rus",
   "recorded": "2018-02-24",
   "related_urls": [
     {
@@ -10,10 +10,13 @@
       "url": "https://web.archive.org/web/20180720115405/https://by.pycon.org/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Grigory Bakunov",
+    "\u0413\u0440\u0438\u0433\u043e\u0440\u0438\u0439 \u0411\u0430\u043a\u0443\u043d\u043e\u0432"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/obKx0Re5qNA/hqdefault.jpg",
-  "title": "\u0413\u0440\u0438\u0433\u043e\u0440\u0438\u0439 \u0411\u0430\u043a\u0443\u043d\u043e\u0432, \u042f\u043d\u0434\u0435\u043a\u0441 - \u0418\u0433\u0440\u0430\u0442\u044c \u0441 \u0418\u0418: \u0441 \u0447\u0435\u0433\u043e \u043d\u0430\u0447\u0430\u0442\u044c \u0438 \u0447\u0435\u043c \u043f\u0440\u043e\u0434\u043e\u043b\u0436\u0438\u0442\u044c",
+  "title": "\u0418\u0433\u0440\u0430\u0442\u044c \u0441 \u0418\u0418: \u0441 \u0447\u0435\u0433\u043e \u043d\u0430\u0447\u0430\u0442\u044c \u0438 \u0447\u0435\u043c \u043f\u0440\u043e\u0434\u043e\u043b\u0436\u0438\u0442\u044c",
   "videos": [
     {
       "type": "youtube",

--- a/pycon-belarus-2018/videos/hynek-schlawack-variomedia-ag-solid-snakes-or-how-to-take-5-weeks-of-vacation.json
+++ b/pycon-belarus-2018/videos/hynek-schlawack-variomedia-ag-solid-snakes-or-how-to-take-5-weeks-of-vacation.json
@@ -10,10 +10,12 @@
       "url": "https://web.archive.org/web/20180720115405/https://by.pycon.org/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Hynek Schlawack"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/1L-uwN0E9m8/maxresdefault.jpg",
-  "title": "Hynek Schlawack, Variomedia AG - Solid Snakes or: How to Take 5 Weeks of Vacation",
+  "title": "Solid Snakes or: How to Take 5 Weeks of Vacation",
   "videos": [
     {
       "type": "youtube",

--- a/pycon-belarus-2018/videos/iuliia-temusheva-wargaming-django-i-aiohttp-opyt-perekhoda-sravnenie-proizvoditelnosti.json
+++ b/pycon-belarus-2018/videos/iuliia-temusheva-wargaming-django-i-aiohttp-opyt-perekhoda-sravnenie-proizvoditelnosti.json
@@ -2,7 +2,7 @@
   "copyright_text": null,
   "description": "",
   "duration": 2064,
-  "language": "eng",
+  "language": "rus",
   "recorded": "2018-02-24",
   "related_urls": [
     {
@@ -10,10 +10,13 @@
       "url": "https://web.archive.org/web/20180720115405/https://by.pycon.org/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Julia Temusheva",
+    "\u042e\u043b\u0438\u044f \u0422\u0435\u043c\u0443\u0448\u0435\u0432\u0430"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/nanNEUFJCWo/maxresdefault.jpg",
-  "title": "\u042e\u043b\u0438\u044f \u0422\u0435\u043c\u0443\u0448\u0435\u0432\u0430, Wargaming - Django \u0438 Aiohttp: \u043e\u043f\u044b\u0442 \u043f\u0435\u0440\u0435\u0445\u043e\u0434\u0430, \u0441\u0440\u0430\u0432\u043d\u0435\u043d\u0438\u0435 \u043f\u0440\u043e\u0438\u0437\u0432\u043e\u0434\u0438\u0442\u0435\u043b\u044c\u043d\u043e\u0441\u0442\u0438",
+  "title": "Django \u0438 Aiohttp: \u043e\u043f\u044b\u0442 \u043f\u0435\u0440\u0435\u0445\u043e\u0434\u0430, \u0441\u0440\u0430\u0432\u043d\u0435\u043d\u0438\u0435 \u043f\u0440\u043e\u0438\u0437\u0432\u043e\u0434\u0438\u0442\u0435\u043b\u044c\u043d\u043e\u0441\u0442\u0438",
   "videos": [
     {
       "type": "youtube",

--- a/pycon-belarus-2018/videos/liza-dovgialo-epam-predskazatelnye-intervaly-dlia-vremennykh-riadov.json
+++ b/pycon-belarus-2018/videos/liza-dovgialo-epam-predskazatelnye-intervaly-dlia-vremennykh-riadov.json
@@ -2,7 +2,7 @@
   "copyright_text": null,
   "description": "",
   "duration": 2544,
-  "language": "eng",
+  "language": "rus",
   "recorded": "2018-02-24",
   "related_urls": [
     {
@@ -10,10 +10,12 @@
       "url": "https://web.archive.org/web/20180720115405/https://by.pycon.org/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "\u041b\u0438\u0437\u0430 \u0414\u043e\u0432\u0433\u044f\u043b\u043e"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/CnDKsnbF0k8/maxresdefault.jpg",
-  "title": "\u041b\u0438\u0437\u0430 \u0414\u043e\u0432\u0433\u044f\u043b\u043e, EPAM - \u041f\u0440\u0435\u0434\u0441\u043a\u0430\u0437\u0430\u0442\u0435\u043b\u044c\u043d\u044b\u0435 \u0438\u043d\u0442\u0435\u0440\u0432\u0430\u043b\u044b \u0434\u043b\u044f \u0432\u0440\u0435\u043c\u0435\u043d\u043d\u044b\u0445 \u0440\u044f\u0434\u043e\u0432",
+  "title": "\u041f\u0440\u0435\u0434\u0441\u043a\u0430\u0437\u0430\u0442\u0435\u043b\u044c\u043d\u044b\u0435 \u0438\u043d\u0442\u0435\u0440\u0432\u0430\u043b\u044b \u0434\u043b\u044f \u0432\u0440\u0435\u043c\u0435\u043d\u043d\u044b\u0445 \u0440\u044f\u0434\u043e\u0432",
   "videos": [
     {
       "type": "youtube",

--- a/pycon-belarus-2018/videos/miroslav-sedivy-ubimet-gmbh-pytables-how-to-store-large-datasets.json
+++ b/pycon-belarus-2018/videos/miroslav-sedivy-ubimet-gmbh-pytables-how-to-store-large-datasets.json
@@ -10,10 +10,12 @@
       "url": "https://web.archive.org/web/20180720115405/https://by.pycon.org/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Miroslav \u0160ediv\u00fd"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/CTFIsBF8xmU/maxresdefault.jpg",
-  "title": "Miroslav \u0160ediv\u00fd, UBIMET GmbH - PyTables: How to Store Large Datasets",
+  "title": "PyTables: How to Store Large Datasets",
   "videos": [
     {
       "type": "youtube",

--- a/pycon-belarus-2018/videos/nicola-iarocci-cir2k-the-eve-rest-apis-for-humans.json
+++ b/pycon-belarus-2018/videos/nicola-iarocci-cir2k-the-eve-rest-apis-for-humans.json
@@ -10,10 +10,12 @@
       "url": "https://web.archive.org/web/20180720115405/https://by.pycon.org/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Nicola Iarocci"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/9zkXSQt5JN8/maxresdefault.jpg",
-  "title": "Nicola Iarocci, CIR2K - The Eve - REST APIs for Humans",
+  "title": "The Eve - REST APIs for Humans",
   "videos": [
     {
       "type": "youtube",

--- a/pycon-belarus-2018/videos/nikolai-kim-microsoft-ispolzovanie-iazyka-programmirovaniia-rust-v-proektakh-napisannykh-na-python.json
+++ b/pycon-belarus-2018/videos/nikolai-kim-microsoft-ispolzovanie-iazyka-programmirovaniia-rust-v-proektakh-napisannykh-na-python.json
@@ -2,7 +2,7 @@
   "copyright_text": null,
   "description": "",
   "duration": 2085,
-  "language": "eng",
+  "language": "rus",
   "recorded": "2018-02-24",
   "related_urls": [
     {
@@ -10,10 +10,12 @@
       "url": "https://web.archive.org/web/20180720115405/https://by.pycon.org/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "\u041d\u0438\u043a\u043e\u043b\u0430\u0439 \u041a\u0438\u043c"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/mt_l0NPG0x8/maxresdefault.jpg",
-  "title": "\u041d\u0438\u043a\u043e\u043b\u0430\u0439 \u041a\u0438\u043c, Microsoft - \u0418\u0441\u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u043d\u0438\u0435 \u044f\u0437\u044b\u043a\u0430 \u043f\u0440\u043e\u0433\u0440\u0430\u043c\u043c\u0438\u0440\u043e\u0432\u0430\u043d\u0438\u044f Rust \u0432 \u043f\u0440\u043e\u0435\u043a\u0442\u0430\u0445, \u043d\u0430\u043f\u0438\u0441\u0430\u043d\u043d\u044b\u0445 \u043d\u0430 Python",
+  "title": "\u0418\u0441\u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u043d\u0438\u0435 \u044f\u0437\u044b\u043a\u0430 \u043f\u0440\u043e\u0433\u0440\u0430\u043c\u043c\u0438\u0440\u043e\u0432\u0430\u043d\u0438\u044f Rust \u0432 \u043f\u0440\u043e\u0435\u043a\u0442\u0430\u0445, \u043d\u0430\u043f\u0438\u0441\u0430\u043d\u043d\u044b\u0445 \u043d\u0430 Python",
   "videos": [
     {
       "type": "youtube",

--- a/pycon-belarus-2018/videos/tarek-ziade-mozilla-building-microservices-in-python.json
+++ b/pycon-belarus-2018/videos/tarek-ziade-mozilla-building-microservices-in-python.json
@@ -10,10 +10,12 @@
       "url": "https://web.archive.org/web/20180720115405/https://by.pycon.org/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "Tarek Ziad\u00e9"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/qyOwW8yDy24/maxresdefault.jpg",
-  "title": "Tarek Ziad\u00e9, Mozilla - Building microservices in Python",
+  "title": "Building microservices in Python",
   "videos": [
     {
       "type": "youtube",

--- a/pycon-belarus-2018/videos/vitalii-khudobakhshov-jetbrains-vnutrennosti-apache-spark.json
+++ b/pycon-belarus-2018/videos/vitalii-khudobakhshov-jetbrains-vnutrennosti-apache-spark.json
@@ -2,7 +2,7 @@
   "copyright_text": null,
   "description": "",
   "duration": 2464,
-  "language": "eng",
+  "language": "rus",
   "recorded": "2018-02-24",
   "related_urls": [
     {
@@ -10,10 +10,12 @@
       "url": "https://web.archive.org/web/20180720115405/https://by.pycon.org/"
     }
   ],
-  "speakers": [],
+  "speakers": [
+    "\u0412\u0438\u0442\u0430\u043b\u0438\u0439 \u0425\u0443\u0434\u043e\u0431\u0430\u0445\u0448\u043e\u0432"
+  ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/R8fTKMLhrwo/maxresdefault.jpg",
-  "title": "\u0412\u0438\u0442\u0430\u043b\u0438\u0439 \u0425\u0443\u0434\u043e\u0431\u0430\u0445\u0448\u043e\u0432, JetBrains - \u0412\u043d\u0443\u0442\u0440\u0435\u043d\u043d\u043e\u0441\u0442\u0438 Apache Spark",
+  "title": "\u0412\u043d\u0443\u0442\u0440\u0435\u043d\u043d\u043e\u0441\u0442\u0438 Apache Spark",
   "videos": [
     {
       "type": "youtube",


### PR DESCRIPTION
Here are these fixes:

- about a half of talks are on russian language
- moved speakers from titles to appropriate sections