### PR TITLE
change speaker name & update link for PyGotham 2019

### DIFF
--- a/pygotham-2019/videos/interact-with-your-code-using-interactive-widgets-in-jupyter-notebooks.json
+++ b/pygotham-2019/videos/interact-with-your-code-using-interactive-widgets-in-jupyter-notebooks.json
@@ -8,7 +8,7 @@
     "https://2019.pygotham.org/talks/interact-with-your-code-using-interactive-widgets-in-jupyter-notebooks/"
   ],
   "speakers": [
-    "Ridhi Mahajan"
+    "Ridhi Kapoor"
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/3BpyWO89qiM/maxresdefault.jpg",
@@ -16,7 +16,7 @@
   "videos": [
     {
       "type": "youtube",
-      "url": "https://youtu.be/3BpyWO89qiM"
+      "url": "https://youtu.be/StvKr-1o3mM"
     }
   ]
 }


### PR DESCRIPTION
This is per the speaker's request. The updated video URL points to a video with the name changed, but otherwise the same as the original.