### PR TITLE
Add videos of online conferences "En attendant la PyConFr" by AFPy - April 2021

### DIFF
--- a/en-attendant-pyconfr-2020-2021/videos/bash-trucs-astuces-mdk.json
+++ b/en-attendant-pyconfr-2020-2021/videos/bash-trucs-astuces-mdk.json
@@ -1,0 +1,23 @@
+{
+  "description": "Trucs et astuces sur l'utilisation de bash pour exploiter au mieux les capacit\u00e9s de son shell",
+  "duration": 1579,
+  "language": "fra",
+  "recorded": "2021-04-15",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://discuss.afpy.org/t/en-attendant-la-pyconfr-du-15-avril-2021/"
+    }
+  ],
+  "speakers": [
+    "mdk"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/GJsdFHcVT3g/hqdefault.jpg",
+  "title": "Bash - trucs & astuces",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=GJsdFHcVT3g"
+    }
+  ]
+}

--- a/en-attendant-pyconfr-2020-2021/videos/enums-jeffd.json
+++ b/en-attendant-pyconfr-2020-2021/videos/enums-jeffd.json
@@ -1,0 +1,23 @@
+{
+    "description": "Pr\u00e9sentation du type Enum en Python et de ses possibilit\u00e9s",
+  "duration": 1127,
+  "language": "fra",
+  "recorded": "2021-04-15",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://discuss.afpy.org/t/en-attendant-la-pyconfr-du-15-avril-2021/"
+    }
+  ],
+  "speakers": [
+    "Jeffd"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/ux3kryAFC7o/hqdefault.jpg",
+  "title": "Les Enums",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=ux3kryAFC7o"
+    }
+  ]
+}

--- a/en-attendant-pyconfr-2020-2021/videos/parallelisme-cgifl300.json
+++ b/en-attendant-pyconfr-2020-2021/videos/parallelisme-cgifl300.json
@@ -1,0 +1,23 @@
+{
+  "description": "Vue d'ensemble sur les techniques de concurrence et de parall\u00e9lisme en Python : asyncio, threads, multiprocessing",
+  "duration": 664,
+  "language": "fra",
+  "recorded": "2021-04-15",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://discuss.afpy.org/t/en-attendant-la-pyconfr-du-15-avril-2021/"
+    }
+  ],
+  "speakers": [
+    "cGIfl300"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/O3VAIc4Lhxo/hqdefault.jpg",
+  "title": "Parall\u00e9lisme",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=O3VAIc4Lhxo"
+    }
+  ]
+}

--- a/en-attendant-pyconfr-2020-2021/videos/performances-de-python-mdk.json
+++ b/en-attendant-pyconfr-2020-2021/videos/performances-de-python-mdk.json
@@ -12,12 +12,12 @@
   "speakers": [
     "mdk"
   ],
-  "thumbnail_url": "https://i.ytimg.com/vi/0NEIZhxWpBU/hqdefault.jpg",
+  "thumbnail_url": "https://i.ytimg.com/vi/tf-spoAWv9k/hqdefault.jpg",
   "title": "Performances de Python",
   "videos": [
     {
       "type": "youtube",
-      "url": "https://www.youtube.com/watch?v=0NEIZhxWpBU"
+      "url": "https://www.youtube.com/watch?v=tf-spoAWv9k"
     },
     {
       "size": 59969243,


### PR DESCRIPTION
Direct links to video files (dl.afpy.org) & peertube instance will come soon.
Ping @pilou- 