### PR TITLE
Fix: DeprecationWarning: invalid escape sequence in tools.

### DIFF
--- a/tools/utils.py
+++ b/tools/utils.py
@@ -60,8 +60,8 @@ def slugify(value, substitutions=()):
             replace = replace and not skip
 
     if replace:
-        value = re.sub('[^\w\s-]', '', value).strip()
-        value = re.sub('[-\s]+', '-', value)
+        value = re.sub(r'[^\w\s-]', '', value).strip()
+        value = re.sub(r'[-\s]+', '-', value)
     else:
         value = value.strip()
 


### PR DESCRIPTION
This fixes:

```text
/home/mdk/clones/data/tools/utils.py:63: DeprecationWarning: invalid escape sequence \w
  value = re.sub('[^\w\s-]', '', value).strip()
/home/mdk/clones/data/tools/utils.py:64: DeprecationWarning: invalid escape sequence \s
  value = re.sub('[-\s]+', '-', value)
```