### PR TITLE
Remove related url to slides repo

### DIFF
--- a/pycon-us-2018/videos/adam-englander-practical-api-security-pycon-2018.json
+++ b/pycon-us-2018/videos/adam-englander-practical-api-security-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/alex-gaynor-learning-from-failure-post-mortems-pycon-2018.json
+++ b/pycon-us-2018/videos/alex-gaynor-learning-from-failure-post-mortems-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/alex-petralia-analyzing-data-what-pandas-and-sql-taught-me-about-taking-an-average-pycon-2018.json
+++ b/pycon-us-2018/videos/alex-petralia-analyzing-data-what-pandas-and-sql-taught-me-about-taking-an-average-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/allen-downey-complexity-science-pycon-2018.json
+++ b/pycon-us-2018/videos/allen-downey-complexity-science-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/allen-downey-introduction-to-digital-signal-processing-pycon-2018.json
+++ b/pycon-us-2018/videos/allen-downey-introduction-to-digital-signal-processing-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/allison-kaptur-love-your-bugs-pycon-2018.json
+++ b/pycon-us-2018/videos/allison-kaptur-love-your-bugs-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/alvaro-leiva-geisse-systemd-why-you-should-care-as-a-python-developer-pycon-2018.json
+++ b/pycon-us-2018/videos/alvaro-leiva-geisse-systemd-why-you-should-care-as-a-python-developer-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/aly-sivji-joe-jasinski-tathagata-dasgupta-t-docker-for-data-science-pycon-2018.json
+++ b/pycon-us-2018/videos/aly-sivji-joe-jasinski-tathagata-dasgupta-t-docker-for-data-science-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/amanda-sopkin-randomness-in-python-creating-chaos-in-an-ordered-machine-controlled-environment.json
+++ b/pycon-us-2018/videos/amanda-sopkin-randomness-in-python-creating-chaos-in-an-ordered-machine-controlled-environment.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     }

--- a/pycon-us-2018/videos/amber-brown-hawkowl-how-we-do-identity-wrong-pycon-2018.json
+++ b/pycon-us-2018/videos/amber-brown-hawkowl-how-we-do-identity-wrong-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/amirali-sanatinia-getting-started-with-blockchains-and-cryptocurrencies-in-python-pycon-2018.json
+++ b/pycon-us-2018/videos/amirali-sanatinia-getting-started-with-blockchains-and-cryptocurrencies-in-python-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/amit-saha-counter-gauge-upper-90-oh-my-pycon-2018.json
+++ b/pycon-us-2018/videos/amit-saha-counter-gauge-upper-90-oh-my-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/amjith-ramanujam-how-netflix-does-failovers-in-7-minutes-flat-pycon-2018.json
+++ b/pycon-us-2018/videos/amjith-ramanujam-how-netflix-does-failovers-in-7-minutes-flat-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/andrew-godwin-taking-django-async-pycon-2018.json
+++ b/pycon-us-2018/videos/andrew-godwin-taking-django-async-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/andrew-knight-behavior-driven-python-pycon-2018.json
+++ b/pycon-us-2018/videos/andrew-knight-behavior-driven-python-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/anna-nicanorova-data-visualization-in-mixed-reality-with-python-pycon-2018.json
+++ b/pycon-us-2018/videos/anna-nicanorova-data-visualization-in-mixed-reality-with-python-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/anna-ossowski-flourishing-floss-making-your-project-successful-pycon-2018.json
+++ b/pycon-us-2018/videos/anna-ossowski-flourishing-floss-making-your-project-successful-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/anubha-maneshwar-pycamp-2k17-a-disclaimer-pycon-2018.json
+++ b/pycon-us-2018/videos/anubha-maneshwar-pycamp-2k17-a-disclaimer-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/barry-warsaw-get-your-resources-faster-with-importlib-resources-pycon-2018.json
+++ b/pycon-us-2018/videos/barry-warsaw-get-your-resources-faster-with-importlib-resources-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/brian-okken-paul-everitt-visual-testing-with-pycharm-and-pytest-pycon-2018.json
+++ b/pycon-us-2018/videos/brian-okken-paul-everitt-visual-testing-with-pycharm-and-pytest-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/carl-meyer-type-checked-python-in-the-real-world-pycon-2018.json
+++ b/pycon-us-2018/videos/carl-meyer-type-checked-python-in-the-real-world-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/carol-willing-practical-sphinx-pycon-2018.json
+++ b/pycon-us-2018/videos/carol-willing-practical-sphinx-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/carol-willing-steam-workshops-using-jupyter-notebooks-jupyterhub-and-binder-pycon-2018.json
+++ b/pycon-us-2018/videos/carol-willing-steam-workshops-using-jupyter-notebooks-jupyterhub-and-binder-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/chalmer-lowe-statistics-and-probability-your-first-steps-on-the-road-to-data-science-pycon-2018.json
+++ b/pycon-us-2018/videos/chalmer-lowe-statistics-and-probability-your-first-steps-on-the-road-to-data-science-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/chris-schuhmacher-coding-through-adversity-pycon-2018.json
+++ b/pycon-us-2018/videos/chris-schuhmacher-coding-through-adversity-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/christopher-beacham-lady-red-visualizing-algorithms-with-python-and-programmable-leds.json
+++ b/pycon-us-2018/videos/christopher-beacham-lady-red-visualizing-algorithms-with-python-and-programmable-leds.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/christopher-fonnesbeck-bayesian-non-parametric-models-for-data-science-using-pymc3-pycon-2018.json
+++ b/pycon-us-2018/videos/christopher-fonnesbeck-bayesian-non-parametric-models-for-data-science-using-pymc3-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     }

--- a/pycon-us-2018/videos/christopher-swenson-colossal-cave-adventure-in-python-in-the-browser-pycon-2018.json
+++ b/pycon-us-2018/videos/christopher-swenson-colossal-cave-adventure-in-python-in-the-browser-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/christy-heaton-intro-to-spatial-analysis-and-maps-with-python-pycon-2018.json
+++ b/pycon-us-2018/videos/christy-heaton-intro-to-spatial-analysis-and-maps-with-python-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/claudio-freire-efficient-shared-memory-data-structures-pycon-2018.json
+++ b/pycon-us-2018/videos/claudio-freire-efficient-shared-memory-data-structures-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/code-like-an-accountant-designing-data-systems-for-accuracy-resilience-and-auditability.json
+++ b/pycon-us-2018/videos/code-like-an-accountant-designing-data-systems-for-accuracy-resilience-and-auditability.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/colin-carroll-karin-c-knudson-fighting-gerrymandering-with-pymc3-pycon-2018.json
+++ b/pycon-us-2018/videos/colin-carroll-karin-c-knudson-fighting-gerrymandering-with-pymc3-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/dan-callahan-keynote-pycon-2018.json
+++ b/pycon-us-2018/videos/dan-callahan-keynote-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     }

--- a/pycon-us-2018/videos/daniel-pyrathon-a-practical-guide-to-singular-value-decomposition-in-python-pycon-2018.json
+++ b/pycon-us-2018/videos/daniel-pyrathon-a-practical-guide-to-singular-value-decomposition-in-python-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/david-beazley-reinventing-the-parser-generator-pycon-2018.json
+++ b/pycon-us-2018/videos/david-beazley-reinventing-the-parser-generator-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     }

--- a/pycon-us-2018/videos/david-gouldin-import-time-travel-a-primer-on-timezones-in-python-pycon-2018.json
+++ b/pycon-us-2018/videos/david-gouldin-import-time-travel-a-primer-on-timezones-in-python-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/debugging-pyspark-or-trying-to-make-sense-of-a-jvm-stack-trace-when-you-were-minding-your-own-bus.json
+++ b/pycon-us-2018/videos/debugging-pyspark-or-trying-to-make-sense-of-a-jvm-stack-trace-when-you-were-minding-your-own-bus.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/devishi-jha-teaching-python-101-pycon-2018.json
+++ b/pycon-us-2018/videos/devishi-jha-teaching-python-101-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     }

--- a/pycon-us-2018/videos/dmitry-filippov-ewa-jodlowska-by-the-numbers-python-community-trends-in-2017-2018-pycon-2018.json
+++ b/pycon-us-2018/videos/dmitry-filippov-ewa-jodlowska-by-the-numbers-python-community-trends-in-2017-2018-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/douglas-blank-jupyter-tools-for-teaching-and-learning-pycon-2018.json
+++ b/pycon-us-2018/videos/douglas-blank-jupyter-tools-for-teaching-and-learning-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/dustin-ingram-inside-the-cheeseshop-how-python-packaging-works-pycon-2018.json
+++ b/pycon-us-2018/videos/dustin-ingram-inside-the-cheeseshop-how-python-packaging-works-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/elizabeth-wickes-hard-shouldn-t-be-hardship-supporting-absolute-novices-to-python-pycon-2018.json
+++ b/pycon-us-2018/videos/elizabeth-wickes-hard-shouldn-t-be-hardship-supporting-absolute-novices-to-python-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/emily-morehouse-valcarcel-the-ast-and-me-pycon-2018.json
+++ b/pycon-us-2018/videos/emily-morehouse-valcarcel-the-ast-and-me-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/emily-xie-making-art-with-python-pycon-2018.json
+++ b/pycon-us-2018/videos/emily-xie-making-art-with-python-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/eric-ma-mridul-seth-network-analysis-made-simple-part-i-pycon-2018.json
+++ b/pycon-us-2018/videos/eric-ma-mridul-seth-network-analysis-made-simple-part-i-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/erin-braswell-python-data-sonification-for-science-and-discovery-pycon-2018.json
+++ b/pycon-us-2018/videos/erin-braswell-python-data-sonification-for-science-and-discovery-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/esther-nam-one-weird-trick-to-becoming-a-better-software-developer-pycon-2018.json
+++ b/pycon-us-2018/videos/esther-nam-one-weird-trick-to-becoming-a-better-software-developer-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/graham-dumpleton-secrets-of-a-wsgi-master-pycon-2018.json
+++ b/pycon-us-2018/videos/graham-dumpleton-secrets-of-a-wsgi-master-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/greg-price-clearer-code-at-scale-static-types-at-zulip-and-dropbox-pycon-2018.json
+++ b/pycon-us-2018/videos/greg-price-clearer-code-at-scale-static-types-at-zulip-and-dropbox-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/harry-percival-intermediate-testing-with-django-outside-in-tdd-and-mocking-effectively.json
+++ b/pycon-us-2018/videos/harry-percival-intermediate-testing-with-django-outside-in-tdd-and-mocking-effectively.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/harry-percival-introduction-to-tdd-with-django-pycon-2018.json
+++ b/pycon-us-2018/videos/harry-percival-introduction-to-tdd-with-django-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/hillel-wayne-beyond-unit-tests-taking-your-testing-to-the-next-level-pycon-2018.json
+++ b/pycon-us-2018/videos/hillel-wayne-beyond-unit-tests-taking-your-testing-to-the-next-level-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/how-we-designed-an-inclusivity-first-conference-on-a-shoestring-budget-and-short-timeline.json
+++ b/pycon-us-2018/videos/how-we-designed-an-inclusivity-first-conference-on-a-shoestring-budget-and-short-timeline.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/hynek-schlawack-how-to-write-deployment-friendly-applications-pycon-2018.json
+++ b/pycon-us-2018/videos/hynek-schlawack-how-to-write-deployment-friendly-applications-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/ian-zelikman-austin-hacker-workflow-engines-up-and-running-pycon-2018.json
+++ b/pycon-us-2018/videos/ian-zelikman-austin-hacker-workflow-engines-up-and-running-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/irina-truong-adapting-from-spark-to-dask-what-to-expect-pycon-2018.json
+++ b/pycon-us-2018/videos/irina-truong-adapting-from-spark-to-dask-what-to-expect-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/jack-diederich-howto-write-a-function-pycon-2018.json
+++ b/pycon-us-2018/videos/jack-diederich-howto-write-a-function-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/jake-vanderplas-exploratory-data-visualization-with-vega-vega-lite-and-altair-pycon-2018.json
+++ b/pycon-us-2018/videos/jake-vanderplas-exploratory-data-visualization-with-vega-vega-lite-and-altair-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/jake-vanderplas-performance-python-seven-strategies-for-optimizing-your-numerical-code.json
+++ b/pycon-us-2018/videos/jake-vanderplas-performance-python-seven-strategies-for-optimizing-your-numerical-code.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/james-bennett-a-bit-about-bytes-understanding-python-bytecode-pycon-2018.json
+++ b/pycon-us-2018/videos/james-bennett-a-bit-about-bytes-understanding-python-bytecode-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/janet-matsen-programming-microbes-using-python-pycon-2018.json
+++ b/pycon-us-2018/videos/janet-matsen-programming-microbes-using-python-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/jason-fried-fighting-the-good-fight-python-3-in-your-organization-pycon-2018.json
+++ b/pycon-us-2018/videos/jason-fried-fighting-the-good-fight-python-3-in-your-organization-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/jason-huggins-keynote-pycon-2018.json
+++ b/pycon-us-2018/videos/jason-huggins-keynote-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     }

--- a/pycon-us-2018/videos/jiaqi-liu-building-a-data-pipeline-with-testing-in-mind-pycon-2018.json
+++ b/pycon-us-2018/videos/jiaqi-liu-building-a-data-pipeline-with-testing-in-mind-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/john-reese-thinking-outside-the-gil-with-asyncio-and-multiprocessing-pycon-2018.json
+++ b/pycon-us-2018/videos/john-reese-thinking-outside-the-gil-with-asyncio-and-multiprocessing-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/josh-lowe-invited-speaker-pycon-2018.json
+++ b/pycon-us-2018/videos/josh-lowe-invited-speaker-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     }

--- a/pycon-us-2018/videos/joyce-jang-build-teams-as-an-engineer-pycon-2018.json
+++ b/pycon-us-2018/videos/joyce-jang-build-teams-as-an-engineer-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/julie-lavoie-beyond-scraping-how-to-use-machine-learning-when-you-re-not-sure-where-to-start.json
+++ b/pycon-us-2018/videos/julie-lavoie-beyond-scraping-how-to-use-machine-learning-when-you-re-not-sure-where-to-start.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/julie-qiu-build-a-search-engine-with-python-elasticsearch-pycon-2018.json
+++ b/pycon-us-2018/videos/julie-qiu-build-a-search-engine-with-python-elasticsearch-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/julie-qiu-strategies-to-edit-production-data-pycon-2018.json
+++ b/pycon-us-2018/videos/julie-qiu-strategies-to-edit-production-data-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/justin-crown-what-is-this-mess-writing-tests-for-pre-existing-code-bases-pycon-2018.json
+++ b/pycon-us-2018/videos/justin-crown-what-is-this-mess-writing-tests-for-pre-existing-code-bases-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/justin-myles-holmes-python-across-the-usa-this-is-the-bus-pycon-2018.json
+++ b/pycon-us-2018/videos/justin-myles-holmes-python-across-the-usa-this-is-the-bus-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/kelsey-pedersen-augmenting-human-decision-making-with-data-science-pycon-2018.json
+++ b/pycon-us-2018/videos/kelsey-pedersen-augmenting-human-decision-making-with-data-science-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/kenneth-reitz-pipenv-the-future-of-python-dependency-management-pycon-2018.json
+++ b/pycon-us-2018/videos/kenneth-reitz-pipenv-the-future-of-python-dependency-management-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/kevin-markham-using-pandas-for-better-and-worse-data-science-pycon-2018.json
+++ b/pycon-us-2018/videos/kevin-markham-using-pandas-for-better-and-worse-data-science-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/kirk-kaiser-birding-with-python-and-machine-learning-pycon-2018.json
+++ b/pycon-us-2018/videos/kirk-kaiser-birding-with-python-and-machine-learning-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/kyle-knapp-automating-code-quality-pycon-2018.json
+++ b/pycon-us-2018/videos/kyle-knapp-automating-code-quality-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/larry-hastings-solve-your-problem-with-sloppy-python-pycon-2018.json
+++ b/pycon-us-2018/videos/larry-hastings-solve-your-problem-with-sloppy-python-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/laura-jacob-genzeal-a-new-generation-of-thinkers-who-design-develop-and-distribute-for-tomorrow.json
+++ b/pycon-us-2018/videos/laura-jacob-genzeal-a-new-generation-of-thinkers-who-design-develop-and-distribute-for-tomorrow.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/liana-bakradze-learning-python-like-a-pro-pycon-2018.json
+++ b/pycon-us-2018/videos/liana-bakradze-learning-python-like-a-pro-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/lightning-talks-friday-pycon-2018.json
+++ b/pycon-us-2018/videos/lightning-talks-friday-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/lightning-talks-saturday-evening-pycon-2018.json
+++ b/pycon-us-2018/videos/lightning-talks-saturday-evening-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     }

--- a/pycon-us-2018/videos/lightning-talks-thursday-pycon-2018.json
+++ b/pycon-us-2018/videos/lightning-talks-thursday-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     }

--- a/pycon-us-2018/videos/lights-camera-action-scrape-explore-and-model-to-predict-oscar-winners-box-office-hits.json
+++ b/pycon-us-2018/videos/lights-camera-action-scrape-explore-and-model-to-predict-oscar-winners-box-office-hits.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/lilly-ryan-don-t-look-back-in-anger-wildman-whitehouse-and-the-great-failure-of-1858-pycon-2018.json
+++ b/pycon-us-2018/videos/lilly-ryan-don-t-look-back-in-anger-wildman-whitehouse-and-the-great-failure-of-1858-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/lisa-roach-demystifying-the-patch-function-pycon-2018.json
+++ b/pycon-us-2018/videos/lisa-roach-demystifying-the-patch-function-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     }

--- a/pycon-us-2018/videos/liz-sander-software-library-apis-lessons-learned-from-scikit-learn-pycon-2018.json
+++ b/pycon-us-2018/videos/liz-sander-software-library-apis-lessons-learned-from-scikit-learn-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/mariatta-wijaya-build-a-github-bot-workshop-pycon-2018.json
+++ b/pycon-us-2018/videos/mariatta-wijaya-build-a-github-bot-workshop-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/mariatta-wijaya-what-is-a-python-core-developer-pycon-2018.json
+++ b/pycon-us-2018/videos/mariatta-wijaya-what-is-a-python-core-developer-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/mario-corchero-effortless-logging-a-deep-dive-into-the-logging-module-pycon-2018.json
+++ b/pycon-us-2018/videos/mario-corchero-effortless-logging-a-deep-dive-into-the-logging-module-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/matt-davis-python-performance-investigation-by-example-pycon-2018.json
+++ b/pycon-us-2018/videos/matt-davis-python-performance-investigation-by-example-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/matthew-rocklin-democratizing-distributed-computing-with-dask-and-jupyterhub-pycon-2018.json
+++ b/pycon-us-2018/videos/matthew-rocklin-democratizing-distributed-computing-with-dask-and-jupyterhub-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/meg-ray-python-for-n00bs-a-cognitive-and-educational-approach-pycon-2018.json
+++ b/pycon-us-2018/videos/meg-ray-python-for-n00bs-a-cognitive-and-educational-approach-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/melanie-crutchfield-code-your-heart-out-beginning-python-for-human-people-with-feelings.json
+++ b/pycon-us-2018/videos/melanie-crutchfield-code-your-heart-out-beginning-python-for-human-people-with-feelings.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/michael-herman-going-serverless-with-openfaas-kubernetes-and-python-pycon-2018.json
+++ b/pycon-us-2018/videos/michael-herman-going-serverless-with-openfaas-kubernetes-and-python-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/miguel-grinberg-oops-i-committed-my-password-to-github-pycon-2018.json
+++ b/pycon-us-2018/videos/miguel-grinberg-oops-i-committed-my-password-to-github-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/mike-muller-faster-python-programs-measure-don-t-guess-pycon-2018.json
+++ b/pycon-us-2018/videos/mike-muller-faster-python-programs-measure-don-t-guess-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/moshe-zadka-web-applications-a-to-z-pycon-2018.json
+++ b/pycon-us-2018/videos/moshe-zadka-web-applications-a-to-z-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/mridul-seth-eric-ma-network-analysis-made-simple-part-ii-pycon-2018.json
+++ b/pycon-us-2018/videos/mridul-seth-eric-ma-network-analysis-made-simple-part-ii-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     }

--- a/pycon-us-2018/videos/nathaniel-j-smith-trio-async-concurrency-for-mere-mortals-pycon-2018.json
+++ b/pycon-us-2018/videos/nathaniel-j-smith-trio-async-concurrency-for-mere-mortals-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/ned-batchelder-big-o-how-code-slows-as-data-grows-pycon-2018.json
+++ b/pycon-us-2018/videos/ned-batchelder-big-o-how-code-slows-as-data-grows-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/nicholas-tollervey-mu-how-to-make-a-kids-code-editor-pycon-2018.json
+++ b/pycon-us-2018/videos/nicholas-tollervey-mu-how-to-make-a-kids-code-editor-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/nicolle-cysneiros-graph-databases-talking-about-your-data-relationships-with-python-pycon-2018.json
+++ b/pycon-us-2018/videos/nicolle-cysneiros-graph-databases-talking-about-your-data-relationships-with-python-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/nina-zakharenko-elegant-solutions-for-everyday-python-problems-pycon-2018.json
+++ b/pycon-us-2018/videos/nina-zakharenko-elegant-solutions-for-everyday-python-problems-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/nir-arad-controlling-apples-with-snakes-automating-mobile-apps-with-appium-pycon-2018.json
+++ b/pycon-us-2018/videos/nir-arad-controlling-apples-with-snakes-automating-mobile-apps-with-appium-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/padmaja-bhagwat-listen-attend-and-walk-interpreting-natural-language-navigational-instructions.json
+++ b/pycon-us-2018/videos/padmaja-bhagwat-listen-attend-and-walk-interpreting-natural-language-navigational-instructions.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/paul-vincent-craven-easy-2d-game-creation-with-arcade-pycon-2018.json
+++ b/pycon-us-2018/videos/paul-vincent-craven-easy-2d-game-creation-with-arcade-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/philip-james-api-driven-django-pycon-2018.json
+++ b/pycon-us-2018/videos/philip-james-api-driven-django-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/philip-james-asheesh-laroia-all-in-the-timing-how-side-channel-attacks-work-pycon-2018.json
+++ b/pycon-us-2018/videos/philip-james-asheesh-laroia-all-in-the-timing-how-side-channel-attacks-work-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/pieter-hooimeijer-types-deeper-static-analysis-and-you-pycon-2018.json
+++ b/pycon-us-2018/videos/pieter-hooimeijer-types-deeper-static-analysis-and-you-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/psf-community-service-awards-catherine-devlin-keynote-final-remarks-pycon-2018.json
+++ b/pycon-us-2018/videos/psf-community-service-awards-catherine-devlin-keynote-final-remarks-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     }

--- a/pycon-us-2018/videos/rae-knowler-python-locales-and-writing-systems-pycon-2018.json
+++ b/pycon-us-2018/videos/rae-knowler-python-locales-and-writing-systems-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/raymond-hettinger-dataclasses-the-code-generator-to-end-all-code-generators-pycon-2018.json
+++ b/pycon-us-2018/videos/raymond-hettinger-dataclasses-the-code-generator-to-end-all-code-generators-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/renato-oliveira-user-focused-api-design-pycon-2018.json
+++ b/pycon-us-2018/videos/renato-oliveira-user-focused-api-design-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/rizky-ariestiyansyah-when-data-meets-education-the-secret-life-of-data-in-education-pycon-2018.json
+++ b/pycon-us-2018/videos/rizky-ariestiyansyah-when-data-meets-education-the-secret-life-of-data-in-education-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/ruben-orduz-nolan-brubaker-a-python-flavored-introduction-to-containers-and-kubernetes.json
+++ b/pycon-us-2018/videos/ruben-orduz-nolan-brubaker-a-python-flavored-introduction-to-containers-and-kubernetes.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/russell-keith-magee-building-a-cross-platform-native-app-with-beeware-pycon-2018.json
+++ b/pycon-us-2018/videos/russell-keith-magee-building-a-cross-platform-native-app-with-beeware-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/sam-kitajima-kimbrel-bowerbirds-of-technology-architecture-and-teams-at-less-than-google-scale.json
+++ b/pycon-us-2018/videos/sam-kitajima-kimbrel-bowerbirds-of-technology-architecture-and-teams-at-less-than-google-scale.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/sara-packman-the-journey-over-the-intermediate-gap-pycon-2018.json
+++ b/pycon-us-2018/videos/sara-packman-the-journey-over-the-intermediate-gap-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/saturday-morning-lightning-talks-keynotes-pycon-2018.json
+++ b/pycon-us-2018/videos/saturday-morning-lightning-talks-keynotes-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     }

--- a/pycon-us-2018/videos/scott-sanderson-foundations-of-numerical-computing-in-python-pycon-2018.json
+++ b/pycon-us-2018/videos/scott-sanderson-foundations-of-numerical-computing-in-python-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/scott-triglia-surviving-and-thriving-when-you-are-overloaded-pycon-2018.json
+++ b/pycon-us-2018/videos/scott-triglia-surviving-and-thriving-when-you-are-overloaded-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/shannon-turner-you-re-an-expert-here-s-how-to-teach-like-one-pycon-2018.json
+++ b/pycon-us-2018/videos/shannon-turner-you-re-an-expert-here-s-how-to-teach-like-one-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/shauna-gordon-mckeon-beyond-django-basics-pycon-2018.json
+++ b/pycon-us-2018/videos/shauna-gordon-mckeon-beyond-django-basics-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/shohei-hido-cupy-a-numpy-compatible-library-for-gpu-pycon-2018.json
+++ b/pycon-us-2018/videos/shohei-hido-cupy-a-numpy-compatible-library-for-gpu-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/skipper-seabold-introduction-to-python-for-data-science-pycon-2018.json
+++ b/pycon-us-2018/videos/skipper-seabold-introduction-to-python-for-data-science-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/stacy-morse-code-reviews-using-art-critique-principles-pycon-2018.json
+++ b/pycon-us-2018/videos/stacy-morse-code-reviews-using-art-critique-principles-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/stephanie-kim-exploring-deep-learning-framework-pytorch-pycon-2018.json
+++ b/pycon-us-2018/videos/stephanie-kim-exploring-deep-learning-framework-pytorch-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/steven-sklar-the-hare-wins-the-race-getting-the-most-out-of-rabbitmq-in-distributed-applications.json
+++ b/pycon-us-2018/videos/steven-sklar-the-hare-wins-the-race-getting-the-most-out-of-rabbitmq-in-distributed-applications.json
@@ -9,10 +9,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/stuart-williams-python-by-immersion-pycon-2018.json
+++ b/pycon-us-2018/videos/stuart-williams-python-by-immersion-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/stuart-williams-python-epiphanies-pycon-2018.json
+++ b/pycon-us-2018/videos/stuart-williams-python-epiphanies-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/sunday-morning-lightning-talks-keynote-pycon-2018.json
+++ b/pycon-us-2018/videos/sunday-morning-lightning-talks-keynote-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     }

--- a/pycon-us-2018/videos/tania-sanchez-monroy-down-the-rabbit-hole-a-101-on-reproducible-workflows-with-python.json
+++ b/pycon-us-2018/videos/tania-sanchez-monroy-down-the-rabbit-hole-a-101-on-reproducible-workflows-with-python.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/the-importance-of-exploratory-data-analysis-and-data-visualization-in-machine-learning-pycon-2018.json
+++ b/pycon-us-2018/videos/the-importance-of-exploratory-data-analysis-and-data-visualization-in-machine-learning-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/tom-augspurger-james-crist-martin-durant-parallel-data-analysis-with-dask-pycon-2018.json
+++ b/pycon-us-2018/videos/tom-augspurger-james-crist-martin-durant-parallel-data-analysis-with-dask-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/trey-hunner-python-2-to-3-how-to-upgrade-and-what-features-to-start-using-pycon-2018.json
+++ b/pycon-us-2018/videos/trey-hunner-python-2-to-3-how-to-upgrade-and-what-features-to-start-using-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/trey-hunner-using-list-comprehensions-and-generator-expressions-for-data-processing-pycon-2018.json
+++ b/pycon-us-2018/videos/trey-hunner-using-list-comprehensions-and-generator-expressions-for-data-processing-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/using-github-travis-ci-and-python-to-introduce-collaborative-software-development-pycon-2018.json
+++ b/pycon-us-2018/videos/using-github-travis-ci-and-python-to-introduce-collaborative-software-development-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/using-python-to-build-an-ai-to-play-and-win-snes-streetfighter-ii-pycon-2018.json
+++ b/pycon-us-2018/videos/using-python-to-build-an-ai-to-play-and-win-snes-streetfighter-ii-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/valery-calderon-reactive-programming-with-rxpy-pycon-2018.json
+++ b/pycon-us-2018/videos/valery-calderon-reactive-programming-with-rxpy-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/van-lindberg-deconstructing-the-us-patent-database-pycon-2018.json
+++ b/pycon-us-2018/videos/van-lindberg-deconstructing-the-us-patent-database-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/victor-stinner-python-3-ten-years-later-pycon-2018.json
+++ b/pycon-us-2018/videos/victor-stinner-python-3-ten-years-later-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/vigneshwer-dhinakaran-pumping-up-python-modules-using-rust-pycon-2018.json
+++ b/pycon-us-2018/videos/vigneshwer-dhinakaran-pumping-up-python-modules-using-rust-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/vm-vicky-brasseur-the-human-nature-of-failure-resiliency-pycon-2018.json
+++ b/pycon-us-2018/videos/vm-vicky-brasseur-the-human-nature-of-failure-resiliency-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/wanjun-zhang-coding-as-enrichment-how-to-empower-students-with-creative-coding-experiences.json
+++ b/pycon-us-2018/videos/wanjun-zhang-coding-as-enrichment-how-to-empower-students-with-creative-coding-experiences.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },

--- a/pycon-us-2018/videos/zekun-li-there-and-back-again-disable-and-re-enable-garbage-collector-at-instagram-pycon-2018.json
+++ b/pycon-us-2018/videos/zekun-li-there-and-back-again-disable-and-re-enable-garbage-collector-at-instagram-pycon-2018.json
@@ -10,10 +10,6 @@
       "url": "https://us.pycon.org/2018/schedule/talks/"
     },
     {
-      "label": "Conference slides (Github)",
-      "url": "https://github.com/PyCon/2018-slides"
-    },
-    {
       "label": "Conference slides (SpeakerDeck)",
       "url": "https://speakerdeck.com/pycon2018"
     },


### PR DESCRIPTION
because the repo is empty. See: https://github.com/PyCon/2018-slides