### PR TITLE
Update outdated gh actions: checkout, setup-python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: [3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
This removes the following warnings from the ci run output:

![Bildschirmfoto 2022-11-13 um 00 53 34](https://user-images.githubusercontent.com/464145/201499174-8d329b72-1f3b-42b6-bde8-2495cedd07d9.jpg)
