### PR TITLE
Change get_json_files to support subfolders as root path

### DIFF
--- a/tools/utils.py
+++ b/tools/utils.py
@@ -1,5 +1,4 @@
-import os
-import glob
+from pathlib import Path
 import re
 
 from jinja2.utils import markupsafe
@@ -9,11 +8,13 @@ import six
 def get_json_files(root, exclude=None):
     exclude = exclude if exclude else set()
 
-    category_pattern = os.path.join(root, '**/category.json')
-    video_pattern = os.path.join(root, '**/videos/*.json')
+    root_path = Path(root)
 
-    category = [path for path in glob.iglob(category_pattern) if path not in exclude]
-    video = [path for path in glob.iglob(video_pattern) if path not in exclude]
+    categories = root_path.rglob('category.json')
+    videos = root_path.rglob('videos/*.json')
+
+    category = [path for path in categories if path not in exclude]
+    video = [path for path in videos if path not in exclude]
 
     return category, video
 


### PR DESCRIPTION
Before it was not possible to provide a subfolder to scripts like `.tests/render_rest.py`. Maybe it was never intended, but I find it helpful for testing only the conf folder, that I am currently working on.

With this change it is possible to only run tests on the json file of a particular conference folder, e.g.
`python .tests/render_rest.py -d ./python-web-conf-2020` The change does not interfere with the original functionality of the script.