### PR TITLE
Update docutils ReST parser settings init.

### DIFF
--- a/.tests/render_rest.py
+++ b/.tests/render_rest.py
@@ -34,8 +34,7 @@ class ReSTValidatorVisitor(docutils.nodes.SparseNodeVisitor):
 
 
 def validate_rest(text):
-    components=(docutils.parsers.rst.Parser,)
-    settings = docutils.frontend.OptionParser(components).get_default_values()
+    settings = docutils.frontend.get_default_settings(rst.Parser)
     document = docutils.utils.new_document('', settings)
     rst.Parser().parse(text, document)
 


### PR DESCRIPTION
This fixes this DeprecationWarning:

```sh
/home/runner/work/data/data/.tests/render_rest.py:38: DeprecationWarning:  
The frontend.OptionParser class will be replaced by a subclass of   
argparse.ArgumentParser in Docutils 0.21 or later.
  settings = docutils.frontend.OptionParser(components).get_default_values()
```