### PR TITLE
PyConFR 2023

### DIFF
--- a/pycon-fr-2023/A-la-decouverte-de-Polars-(ou-pourquoi-vous-pourriez-quitter-pandas).json
+++ b/pycon-fr-2023/A-la-decouverte-de-Polars-(ou-pourquoi-vous-pourriez-quitter-pandas).json
@@ -1,0 +1,17 @@
+{
+    "title": "\u00c0 la d\u00e9couverte de Polars (ou pourquoi vous pourriez quitter pandas)",
+    "description": "J'utilise pandas pour g\u00e9rer des datasets depuis 2016. C'est encore aujourd'hui la librairie de r\u00e9f\u00e9rence quand il s'agit de manipuler des donn\u00e9es. Cependant, cette librairie n'est pas exempte de d\u00e9fauts. Polars propose une alternative int\u00e9ressante \u00e0 pandas. Migrer vers polars est facile car cette librairie propose une API proche de pandas. Enfin, son api \"lazy\" et ses performances finiront par vous convaincre que, oui, il faut au moins essayer polars.",
+    "duration": 1881,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Olivier Hervieu"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 259967905,
+            "url": "https://dl.afpy.org/pycon-fr-23//Olivier%20Hervieu%20-%20%C3%80%20la%20d%C3%A9couverte%20de%20Polars%20%28ou%20pourquoi%20vous%20pourriez%20quitter%20pandas%29.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Accessibilite-numerique:-faire-sa-part-quand-on-est-developpeureuse-backend.json
+++ b/pycon-fr-2023/Accessibilite-numerique:-faire-sa-part-quand-on-est-developpeureuse-backend.json
@@ -1,0 +1,17 @@
+{
+    "title": "Accessibilit\u00e9 num\u00e9rique\u202f: faire sa part quand on est d\u00e9veloppeur\u00b7euse backend",
+    "description": "Quand on pense aux probl\u00e9matiques d\u2019accessibilit\u00e9 num\u00e9rique, on a vite \u00e0 penser qu\u2019il s'agit d\u2019un souci de front-end uniquement. Que ces designers se d\u00e9brouillent bien tou\u00b7te\u00b7s seul\u00b7es.\n\nQue nenni. L\u2019accessibilit\u00e9 est une probl\u00e9matique qu\u2019on retrouve \u00e0 tous les niveaux, incluant les serveurs. Vous \u00eates d\u00e9veloppeur\u00b7euse backend et vous voulez contribuer \u00e0 faire votre part pour que le monde num\u00e9rique soit plus ouvert aux personnes ayant des difficult\u00e9s ou des handicaps ? Alors, venez, on va en parler.",
+    "duration": 2316,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Amaury Carrade"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 2013403554,
+            "url": "https://dl.afpy.org/pycon-fr-23//Amaury%20Carrade%20-%20Accessibilit%C3%A9%20num%C3%A9rique%20faire%20sa%20part%20quand%20on%20est%20d%C3%A9veloppeur%C2%B7euse%20backend.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Apport-du-langage-Python-dans-un-service-de-recherche-hospitaliere-pour-mener-des-analyses-de-deep-learning.json
+++ b/pycon-fr-2023/Apport-du-langage-Python-dans-un-service-de-recherche-hospitaliere-pour-mener-des-analyses-de-deep-learning.json
@@ -1,0 +1,17 @@
+{
+    "title": "Apport du langage Python dans un service de recherche hospitali\u00e8re pour mener des analyses de deep learning",
+    "description": "Dans les services hospitaliers de recherche cliniques, l'utilisation de python est peu commune, par rapport \u00e0 d'autres langages de programmation comme R. Mais le d\u00e9veloppement du machine learning et du deep learning oriente pr\u00e9f\u00e9rentiellement vers le langage python.\n\nNous montrerons comment le deep learning permet de r\u00e9soudre des probl\u00e9matiques m\u00e9dicales. Par exemple, dans le cadre de la transplantation d'un rein chez un patient, le m\u00e9decin surveille le patient et redoute deux \u00e9v\u00e9nements graves : le d\u00e9c\u00e8s du patient et le retour en dialyse (=perte du greffon). Lorsque le greffon r\u00e9nal ne peut plus accomplir sa fonction, une mise sous dialyse est n\u00e9cessaire ce qui est tr\u00e8s lourd pour le patient et cher pour la s\u00e9curit\u00e9 sociale. En effet, la dialyse repr\u00e9sente plusieurs s\u00e9ances par semaine de plusieurs heures. Des mod\u00e8les statistiques et de deep learning cod\u00e9s en python que nous avons d\u00e9velopp\u00e9s permettent d'anticiper la d\u00e9faillance du greffon ce qui permettrait au m\u00e9decin de suivre de mani\u00e8re plus rapproch\u00e9e les patients si n\u00e9cessaire et de retarder voire \u00e9viter la perte du greffon et le retour en dialyse associ\u00e9. Les challenges auxquels nous faisons face sont les suivants :\n1) Le machine learning et, a fortiori, le deep learning r\u00e9clament des puissances de calcul consid\u00e9rables, une mutualisation des ressources et une technologie adapt\u00e9e sont n\u00e9cessaires.\n2) Le deep learning est performant pour les gros volumes de donn\u00e9es, ainsi l'acc\u00e8s aux donn\u00e9es de la S\u00e9curit\u00e9 sociale permettra d'obtenir des mod\u00e8les plus performants.",
+    "duration": 2585,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Cl\u00e9ment Benoist"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 2128911299,
+            "url": "https://dl.afpy.org/pycon-fr-23//Cl%C3%A9ment%20Benoist%20-%20Apport%20du%20langage%20Python%20pour%20mener%20des%20analyses%20de%20deep%20learning.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Apprendre-Python,-cest-pour-tout-le-monde-en-2023!.json
+++ b/pycon-fr-2023/Apprendre-Python,-cest-pour-tout-le-monde-en-2023!.json
@@ -1,0 +1,17 @@
+{
+    "title": "Apprendre Python, c\u2019est pour tout le monde en 2023\u202f!\u202f\ud83d\udc9e",
+    "description": "Qui veut apprendre \u00e0 utiliser Python en 2023 et d'ailleurs pourquoi ce langage ?\nQuels sont les moyens d'apprentissage \u00e0 notre disposition en 2023 ?\nJe vais essayer de vous d\u00e9crire tout cela et vous pourrez repartir avec plein de suggestions et d'outils.\n\nDe plus en plus fr\u00e9quemment, la question d'apprendre un langage de programmation se pose et ce pour des profils tr\u00e8s vari\u00e9s.\n\nEn premier lieu, il y a les enfants bien s\u00fbr, que ce soit par l'\u00e9cole ou par eux m\u00eame.\nPas forc\u00e9ment dans l'objectif d'en faire une profession, mais conna\u00eetre les bases de la programmation est une cl\u00e9 pour appr\u00e9hender le monde num\u00e9rique qui les entoure et avoir une chance de comprendre au del\u00e0 de consommer.\n\nLes adultes ensuite, et l\u00e0 les besoins sont tr\u00e8s vari\u00e9s.\nCertain\u00b7es seront en reconversion et sont \u00e0 la recherche d'une nouvelle voie professionnelle ou bien compl\u00e9teront leurs comp\u00e9tences avec une touche de programmation.\nD'autres auront de nouveaux projets informatiques et auront besoin d'ajouter Python \u00e0 la liste des languages et outils qu'ils ma\u00eetrisent.\n\nA tout ce petit monde, Python permettra d'apprendre \u00e0 son rythme, en ajoutant peu \u00e0 peu les concepts, sans jamais fermer de portes pour le futur.\nPython est en effet un langage \u00e0 la fois simple dans les premiers pas, mais \u00e9galement tr\u00e8s complet quand par la suite on souhaite aborder des architectures logicielles complexes dans des domaines aussi vari\u00e9s et diff\u00e9rents que des applications web, du Machine Learning ou de l'outillage d'int\u00e9gration continue...\n\nViendra ensuite la question des outils \u00e0 notre disposition et l\u00e0, le temps qui s'\u00e9coule a apport\u00e9 une grande palette de solutions.\nNous verrons ce que l'on peut faire avec des outils graphiques comme Makecode ou Edublocks, puis nous verrons comment effectuer la transition vers le code lui m\u00eame avec des \u00e9diteurs de plus en plus aptes \u00e0 accompagner l'apprentissage.\nJe vous proposerait \u00e9galement un tour des plateformes permettant d'avoir de v\u00e9ritables curriculum complets le tout dans un environnement riche o\u00f9 textes d'explications et vid\u00e9os s'accompagneront parfois de petits jeux pour gravir une \u00e0 une les marches menant \u00e0 la connaissance de Python.\n\nVous devriez alors \u00eatre capable de vous lancer vous m\u00eame ou bien accompagner les personnes dans votre entourage qui souhaiterai plonger dans cet univers passionnant de la programmation Python.",
+    "duration": 1601,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Thierry Chantier"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 226446669,
+            "url": "https://dl.afpy.org/pycon-fr-23//Thierry%20Chantier%20-%20Apprendre%20Python%2C%20c%27est%20pour%20tout%20le%20monde%20en%202023%20%21.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Apprentissage-statistique-adapte-aux-donnees-sales-avec-dirty-cat.json
+++ b/pycon-fr-2023/Apprentissage-statistique-adapte-aux-donnees-sales-avec-dirty-cat.json
@@ -1,0 +1,17 @@
+{
+    "title": "Apprentissage statistique adapt\u00e9 aux donn\u00e9es sales avec dirty-cat",
+    "description": "Les data scientists sont souvent amen\u00e9s \u00e0 travailler avec des donn\u00e9es non standardis\u00e9es (avec erreurs de frappes, abr\u00e9viations, duplications, valeurs manquantes...).\n\nLe traitement ou nettoyage des donn\u00e9es prend un temps consid\u00e9rable sans fournir la garantie d'un bon r\u00e9sultat final.\n\ndirty-cat est une librairie open source en Python qui permet de faciliter le traitement des donn\u00e9es sales dans le but de faire de l'apprentissage statistique.\n\nLe point de d\u00e9part est souvent une collection de tables provenant de sources diff\u00e9rentes. Il faut par la suite:\n\n- joindre ces tables sur des cat\u00e9gories impr\u00e9cises (par exemple 'Bordeaux, FR' et 'Bordeaux');\n- d\u00e9dupliquer les valeurs d'une cat\u00e9gorie;\n- faire de l'encodage de ces cat\u00e9gories sachant que leur cardinalit\u00e9 peut \u00eatre grande due \u00e0 la pr\u00e9sence de valeurs inexactes.\n\nDans cette pr\u00e9sentation, je vais vous montrer les m\u00e9thodes et fonctions de dirty-cat et comment elles nous permettent d'obtenir de meilleurs r\u00e9sultats tout en diminuant le travail n\u00e9cessaire \u00e0 la pr\u00e9paration des donn\u00e9es.\n\nPour quelques exemples d'utilisation de dirty-cat voir:\n\n- https://dirty-cat.github.io/stable/\n- https://github.com/dirty-cat/dirty_cat/tree/main/examples",
+    "duration": 1728,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Jovan Stojanovic"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 187239830,
+            "url": "https://dl.afpy.org/pycon-fr-23//Jovan%20Stojanovic%20-%20Apprentissage%20statistique%20adapt%C3%A9%20aux%20donn%C3%A9es%20sales%20avec%20dirty-cat.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Assemblee-generale-de-lAFPy.json
+++ b/pycon-fr-2023/Assemblee-generale-de-lAFPy.json
@@ -1,0 +1,17 @@
+{
+    "title": "Assembl\u00e9e g\u00e9n\u00e9rale de l\u2019AFPy",
+    "description": "Assembl\u00e9e g\u00e9n\u00e9rale de l'Association Francophone Python, organisatrice de l'\u00e9v\u00e9nement. Vous pouvez venir pour conna\u00eetre le bilan de cette ann\u00e9e et participer aux choix des prochaines \u00e9ditions. Les membres \u00e0 jour de cotisation peuvent \u00e9galement prendre part aux votes et candidater pour faire partie du comit\u00e9 de direction.",
+    "duration": 2975,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Marc Debureaux"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 406570611,
+            "url": "https://dl.afpy.org/pycon-fr-23//Marc%20Deburreaux%20-%20Assembl%C3%A9e%20G%C3%A9n%C3%A9rale%20PyConFr%202023.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Cerveau,-Biomarqueurs-et-Deep-Learning.json
+++ b/pycon-fr-2023/Cerveau,-Biomarqueurs-et-Deep-Learning.json
@@ -1,0 +1,17 @@
+{
+    "title": "Cerveau, Biomarqueurs et Deep Learning",
+    "description": "Construction d'une plateforme de calcul et de visualisation de biomarqueurs de une maladie d\u00e9g\u00e9n\u00e9rative \u00e0 l'aide d'images IRM du cerveau et du deep learning sur Google Cloud",
+    "duration": 1740,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Facundo Calcagno"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 206280539,
+            "url": "https://dl.afpy.org/pycon-fr-23//Facundo%20Calcagno%20-%20Cerveau%2C%20Biomarqueurs%20et%20Deep%20Learning%20-%20PyConFr2023.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Cloture-du-samedi.json
+++ b/pycon-fr-2023/Cloture-du-samedi.json
@@ -1,0 +1,17 @@
+{
+    "title": "Cl\u00f4ture du samedi",
+    "description": "Session de cl\u00f4ture de la journ\u00e9e du samedi.\n\nClosing talk of Saturday.",
+    "duration": 1134,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Marc Debureaux"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 174318592,
+            "url": "https://dl.afpy.org/pycon-fr-23//Marc%20Debureaux%20-%20Cl%C3%B4ture%20du%20samedi.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Cloud-infrastructure-from-Python-code:-how-far-could-we-go?.json
+++ b/pycon-fr-2023/Cloud-infrastructure-from-Python-code:-how-far-could-we-go?.json
@@ -1,0 +1,17 @@
+{
+    "title": "Cloud infrastructure from Python code: how far could we go?",
+    "description": "In this talk, I'm going to clarify the Infrastructure As Code (IaC) paradigm and its limitations, analyze the exact problems that Infrastructure From Code (IfC) is supposed to solve, compare recent IfC offerings, and propose what could and, in my opinion, should be done for the Python ecosystem. I will also share my personal experience of implementing such a system, code-named Cloud AI Operating System (CAIOS): what went well, what still needs to be resolved, and where, in my view, the Python community could contribute in making Python as the number one choice for cloud programming language.\n\nInfrastructure as Code - the use of repeatable scripts or SDKs to configure the cloud environment for an application - has expanded the possibilities of Serverless with Continuous Delivery. However, there are fundamental issues with IaC: it is a time-consuming and tedious process to prepare the scripts, the activity requires the involvement of DevSecOps experts, and the scripts are only loosely related to the application code. For any non-trivial application, these scripts grow very quickly in complexity and size. Applying IaC to optimize the configuration of the test, staging, and production environments only exacerbates these issues.\n\nInfrastructure from Code is a recent advancement over IaC that addresses these obstacles. IfC interprets a mainstream programming language code and automatically generates the specifications needed to configure a cloud environment. So far, the most advanced solutions, such as ServerlessCloud, Ampt, or Nitric, were proposed for the TypeScript ecosystem. While, for Python, AWS Chalice is a cloud-vendor-specific solution and offers a relatively limited feature set.",
+    "duration": 1639,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Asher Sterkin"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 1345150812,
+            "url": "https://dl.afpy.org/pycon-fr-23//Asher%20Sterkin%20-%20Cloud%20infrastructure%20from%20Python%20code.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/CoWorks,-a-compositionnal-microservices-framework-using-Flask-AWS-Lamba-and-Airflow.json
+++ b/pycon-fr-2023/CoWorks,-a-compositionnal-microservices-framework-using-Flask-AWS-Lamba-and-Airflow.json
@@ -1,0 +1,17 @@
+{
+    "title": "CoWorks, a compositionnal microservices framework using Flask/AWS Lamba and Airflow",
+    "description": "CoWorks, a streamlined experience for building microservices.\n\nCoWorks (https://github.com/gdoumenc/coworks) is a unified serverless microservices framework based on AWS technologies (API Gateway, AWS Lambda), Flask framework (Flask/Click) and the Airflow platform.\n\nThis talk will cover:\n * overview of the concepts: tech vs business micro-services\n * advantages of the framework: modularity, maintenance, ability to scale\n * feedback from a live customer - NeoRezo (https://neorezo.io/)..",
+    "duration": 2793,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Guillaume Doumenc"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 2180456425,
+            "url": "https://dl.afpy.org/pycon-fr-23//Guillaume%20Doumenc%20-%20CoWorks%2C%20a%20compositionnal%20microservices%20framework%20using%20FlaskAWS%20Lamba%20and%20Airflow.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Continuous-performance-analysis-for-Python.json
+++ b/pycon-fr-2023/Continuous-performance-analysis-for-Python.json
@@ -1,0 +1,17 @@
+{
+    "title": "Continuous performance analysis for Python",
+    "description": "We'll start by covering the basics of benchmarking in python and explore the limits of time-based measurements.\nThen, we'll see how CodSpeed helped Pydantic throughout the rust migration, demonstrating the actual impact of the Rust migration on the overall performance.\nFinally, we'll cover how CodSpeed can be set up on any Python project to consistently track the performances of your codebase.",
+    "duration": 1984,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Arthur Pastel"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 1766684842,
+            "url": "https://dl.afpy.org/pycon-fr-23//Arthur%20Pastel%20-%20Continuous%20performance%20analysis%20por%20Python.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Deployer-du-backend-en-2023.json
+++ b/pycon-fr-2023/Deployer-du-backend-en-2023.json
@@ -1,0 +1,17 @@
+{
+    "title": "D\u00e9ployer du backend en 2023",
+    "description": "Comment d\u00e9ployer un backend web en 2023. Que ce soit du Django, Flask, FastAPI ou autre, une fois d\u00e9velopp\u00e9e, il faut bien mettre notre application en production.\nQuelles sont les implications sur le d\u00e9veloppement. Mais surtout comment gagner du temps en anticipant un peu certaines choses.\nEt puis quelques d\u00e9mos qui marchent. Ou pas.\n\n--\n\nHow to deploy a web backend in 2023. Whether it's Django, Flask, FastAPI or other, once developed, we must put our application in production.\nWhat are the implications on the development. But above all, how to save time by anticipating certain things.\nAnd then some demos that work. Or not.",
+    "duration": 3249,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Nicolas Ledez"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 2633721316,
+            "url": "https://dl.afpy.org/pycon-fr-23//Nicolas%20Ledez%20-%20d%C3%A9ployer%20du%20backend%20en%202023.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Developpement-VRAIMENT-cross-platform-avec-Python.json
+++ b/pycon-fr-2023/Developpement-VRAIMENT-cross-platform-avec-Python.json
@@ -1,0 +1,17 @@
+{
+    "title": "D\u00e9veloppement VRAIMENT cross-platform avec Python",
+    "description": "Dans le cadre du projet WitnessAngel, nous avons tenu \u00e0 cr\u00e9er une base de code open-source r\u00e9ellement multiplatforme, c'est \u00e0 dire capable de tourner sous Linux, MacOS, Windows, Android et iOS, aussi bien sur architecture x32/x64 que sur processeur ARM (ex. Raspberry Pi).\n\nCe retour d'exp\u00e9rience va pr\u00e9senter nos choix technologiques, les nombreuses contraintes et astuces pour obtenir ce niveau de compatibilit\u00e9, ainsi que les processus \u00e0 respecter pour packager, signer et distribuer les logiciels sur chaque plateforme.\n\nSLIDES : https://v.gd/ZA3XLv",
+    "duration": 3516,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Pascal Chambon"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 3010097805,
+            "url": "https://dl.afpy.org/pycon-fr-23//Pascal%20Chambon%20-%20D%C3%A9veloppement%20VRAIMENT%20cross-platform%20avec%20Python.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Devenir-incollable-sur-les-callables!.json
+++ b/pycon-fr-2023/Devenir-incollable-sur-les-callables!.json
@@ -1,0 +1,17 @@
+{
+    "title": "Devenir incollable sur les callables\u202f!",
+    "description": "Il n'y a pas que les fonctions qui sont appelables en Python\u00a0: on peut aussi appeler des types (`int()`), des m\u00e9thodes (`foo.bar()`) et plus g\u00e9n\u00e9ralement toutes sortes d'objets bien particuliers.\nQuels sont-ils\u00a0? Comment fonctionnent-ils\u00a0? Et plus g\u00e9n\u00e9ralement que se passe-t-il lors d'un appel\u00a0?\nCe sont \u00e0 ces questions qu'entend r\u00e9pondre la pr\u00e9sentation.\nSeront aussi abord\u00e9es les notions d'arguments et de param\u00e8tres, les diff\u00e9rents types d'arguments (positionnels, nomm\u00e9s), les signatures de fonctions et les d\u00e9corateurs.",
+    "duration": 3743,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Antoine Rozo"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 418307486,
+            "url": "https://dl.afpy.org/pycon-fr-23//Antoine%20Rozo%20-%20Devenir%20incollable%20sur%20les%20callables%20%21.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Discours-d'ouverture.json
+++ b/pycon-fr-2023/Discours-d'ouverture.json
@@ -1,0 +1,17 @@
+{
+    "title": "Discours d'ouverture",
+    "description": "Session d'ouverture de PyConFr 2023.\n\nOpening talk for PyConFr 2023.",
+    "duration": 2143,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Marc Debureaux"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 289304078,
+            "url": "https://dl.afpy.org/pycon-fr-23//Marc%20Debureaux%20-%20Discours%20d%27ouverture.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Discours-de-cloture.json
+++ b/pycon-fr-2023/Discours-de-cloture.json
@@ -1,0 +1,17 @@
+{
+    "title": "Discours de cl\u00f4ture",
+    "description": "Session de cl\u00f4ture de la PyConFR 2023.\n\nClosing talk of PyConFR 2023.",
+    "duration": 1156,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Marc Debureaux"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 183533412,
+            "url": "https://dl.afpy.org/pycon-fr-23//Marc%20Debureaux%20-%20Discours%20de%20cl%C3%B4ture.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Django-Admin-comme-framework-pour-developper-des-outils-internes.json
+++ b/pycon-fr-2023/Django-Admin-comme-framework-pour-developper-des-outils-internes.json
@@ -1,0 +1,17 @@
+{
+    "title": "Django Admin comme framework pour d\u00e9velopper des outils internes",
+    "description": "Si vous d\u00e9veloppez des applications avec le framework Django, vous connaissez s\u00fbrement Django Admin pour introspecter votre base de donn\u00e9es et effectuer quelques op\u00e9rations de maintenance. Mais savez-vous qu'il est possible de d\u00e9velopper des applications compl\u00e8tes gr\u00e2ce \u00e0 Django Admin ?\n\nDjango Admin poss\u00e8de des secrets bien gard\u00e9s mais une fois d\u00e9couverts, beaucoup de possibilit\u00e9s s'offrent \u00e0 nous. De la gestion de permissions avanc\u00e9e \u00e0 l'ajout de pages et formulaires personnalis\u00e9s en passant par l'int\u00e9gration d'automatisations, d\u00e9velopper des outils m\u00e9tiers devient un jeu d'enfant.\n\nDans cette pr\u00e9sentation, je vous partagerez mon retour d'exp\u00e9rience sur l'utilisation de Django Admin comme framework \u00e0 part enti\u00e8re dans le cadre de d\u00e9veloppement d'applications internes centr\u00e9es sur les donn\u00e9es.\n\nLes applications \"no-code\" n'ont qu'\u00e0 bien se tenir !",
+    "duration": 1665,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Romain Clement"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 193921425,
+            "url": "https://dl.afpy.org/pycon-fr-23//Romain%20Cl%C3%A9ment%20-%20Django%20Admin%20comme%20framework%20pour%20d%C3%A9velopper%20des%20outils%20internes.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Documentation,-logiciel-libre-et-perennite-en-arts-numeriques.json
+++ b/pycon-fr-2023/Documentation,-logiciel-libre-et-perennite-en-arts-numeriques.json
@@ -1,0 +1,17 @@
+{
+    "title": "Documentation, logiciel libre et p\u00e9rennit\u00e9 en arts num\u00e9riques",
+    "description": "Les arts num\u00e9riques posent des d\u00e9fis de conservation et de pr\u00e9servation importants, de par leurs contraintes mat\u00e9rielles et logicielles.\n\nUne utilisation judicieuse de composantes sous licence libre peut favoriser la p\u00e9rennit\u00e9 des oeuvres r\u00e9alis\u00e9es avec les technologies modernes.\n\nUne documentation technique ad\u00e9quate constitue un facteur de succ\u00e8s important pour un tel projet. Voici quelques r\u00e9flexions sur le sujet ainsi que des lignes directrices pour vous guider, bas\u00e9s sur notre exp\u00e9rience avec Sphinx, le logiciel utilis\u00e9 pour la documentation de Python, au Metalab, le laboratoire de recherche et d\u00e9veloppement de la Soci\u00e9t\u00e9 des arts technologiques (Montr\u00e9al, Qu\u00e9bec, Canada).",
+    "duration": 3404,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "\u00c9dith Viau"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 357993102,
+            "url": "https://dl.afpy.org/pycon-fr-23//%C3%89dith%20Viau%20-%20Documentation%2C%20logiciel%20libre%20et%20p%C3%A9rennit%C3%A9%20en%20arts%20num%C3%A9riques.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Domain-driven-design:-what-can-Python-do-for-you?.json
+++ b/pycon-fr-2023/Domain-driven-design:-what-can-Python-do-for-you?.json
@@ -1,0 +1,17 @@
+{
+    "title": "Domain-driven design: what can Python do for you?",
+    "description": "Through various examples, we will start defining the advantages of domain-driven design and how it translates using the latest improvements in Python, notably with the use of data classes and typing.\n\nWe will aim to write better, clearer, and simpler Python in this talk.",
+    "duration": 1402,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "David Kremer"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 1255621226,
+            "url": "https://dl.afpy.org/pycon-fr-23//David%20Kremer%20-%20Domain-driver%20design%20what%20can%20Python%20do%20for%20you.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Driving-down-the-Memray-lane---Profiling-your-data-science-work.json
+++ b/pycon-fr-2023/Driving-down-the-Memray-lane---Profiling-your-data-science-work.json
@@ -1,0 +1,17 @@
+{
+    "title": "Driving down the Memray lane - Profiling your data science work",
+    "description": "In this talk, we will be exploring what memory profiling is, and how it can help with data science work. We will start the talk with a basic explanation of how Python arrange memories for various objects. This lays the foundation explanation of why we need a special tool to memory profile Python programs.\n\nThen we will be going through a data science use case where we memory profiles some part of the process with the Memray Jupyter plug-in. This would be a use case that a data science practitioner or learner would be familiar with and they can see how memory profiling could be useful.\n\nWe will then explain how to interpret the frame diagram in Memray, a commonly used diagram in memory profiling to understand how much memory a process and its sub-process uses. This is something that for a new user, it could be hard to understand and not know what to look into. From this example, audiences can see what they can learn about from the frame diagram.\n\n#### Goal\n\nThis talk is for data scientists, learners or anyone who is interested in memory profiling their Python program. Although the talk will be using a data science use case as an example, the explanation and the tool can be expanded to be used in any Python program. However, for data science practitioners and learners who have been using Python to process data, this may be a step forward for them to improve their data workflow and prevent memory leaks from their programs.",
+    "duration": 1737,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Cheuk Ting Ho"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 1639463807,
+            "url": "https://dl.afpy.org/pycon-fr-23//Cheuk%20Ting%20Ho%20-%20Driving%20down%20the%20Memray%20lane%20-%20Profiling%20your%20data%20science%20work.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Fear-the-mutants.-Love-the-mutants..json
+++ b/pycon-fr-2023/Fear-the-mutants.-Love-the-mutants..json
@@ -1,0 +1,17 @@
+{
+    "title": "Fear the mutants. Love the mutants.",
+    "description": "Code coverage (the percentage of your code tested by your tests) is a great metric. However, coverage doesn\u2019t tell you how good your tests are at picking up changes to your codebase - if your tests aren\u2019t well-designed, changes can pass your unit tests but break production. And what better way to explain this than with penguins?\n\nMutation testing is a great (and massively underrated) way to quantify how much you can trust your tests. Mutation tests work by changing your code in subtle ways, then applying your unit tests to these new, \"mutant\" versions of your code. If your tests fail, great! If they pass\u2026 that\u2019s a change that might cause a bug in production.\n\nIn this talk, I\u2019ll show you how to get started with mutation testing and how to integrate it into your CI/CD pipeline. After the session, you\u2019ll be ready to use mutation testing with wild abandon. Soon, catching mutant code will be a routine part of your release engineering process, and you'll never look at penguins the same way again!",
+    "duration": 1859,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Max Kahan"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 1414160344,
+            "url": "https://dl.afpy.org/pycon-fr-23//Max%20Kahan%20-%20Fear%20the%20mutants%2C%20Love%20the%20mutants.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Fixed-bugs-nest-peut-etre-pas-le-meilleur-message-de-commit.json
+++ b/pycon-fr-2023/Fixed-bugs-nest-peut-etre-pas-le-meilleur-message-de-commit.json
@@ -1,0 +1,17 @@
+{
+    "title": "\u00ab\u202fFixed bugs\u202f\u00bb n\u2019est peut-\u00eatre pas le meilleur message de commit",
+    "description": "Si vos commits font tous 3000 lignes, vos messages 3 mots, votre historique ressemble \u00e0 des spaghetti et que la question \"qui a introduit cette ligne et pourquoi ?\" vous fait peur, il y a quelque chose pour vous ! Sinon, invitez vos coll\u00e8gues qui n'ont pas autant de sagesse, \u00e7a vous fera toujours gagner du temps.\n\nCette pr\u00e9sentation essayera de vous convaincre de l'\u00e9norme utilit\u00e9 de maintenir et naviguer dans un historique propre, peu importe l'outil que vous utilisez, le projet sur lequel vous travaillez ou le langage dans lequel vous \u00e9crivez.",
+    "duration": 3426,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Rapha\u00ebl Gom\u00e8s"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 2579769793,
+            "url": "https://dl.afpy.org/pycon-fr-23//Rapha%C3%ABl%20Gom%C3%A8s%20-%20Fixed%20bugs%20n%27est%20peut-%C3%AAtre%20pas%20le%20meilleur%20message%20de%20commit.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/GEMSEO:-une-bibliotheque-pour-loptimisation-multi-disciplinaire.json
+++ b/pycon-fr-2023/GEMSEO:-une-bibliotheque-pour-loptimisation-multi-disciplinaire.json
@@ -1,0 +1,18 @@
+{
+    "title": "GEMSEO\u202f: une biblioth\u00e8que pour l\u2019optimisation multi-disciplinaire",
+    "description": "De nombreux probl\u00e8mes d\u2019ing\u00e9nieries impliquant des disciplines diverses (physiques, \u00e9conomiques, ...) cherchent \u00e0 trouver un meilleur compromis comme solution. Cela implique l'utilisation d'algorithmes math\u00e9matiques (optimisation, DOE, ...) ainsi qu'une orchestration du processus impliquant les diff\u00e9rentes disciplines. La librairie GEMSEO propose de simplifier l\u2019acc\u00e8s \u00e0 des algorithmes open sources (et propri\u00e9taires), ainsi que de simplifier la cr\u00e9ation et la reconfiguration du processus. GEMSEO facilite \u00e9galement l'exploitation des r\u00e9sultats avec des outils de visualisation.",
+    "duration": 1613,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Jean-Christophe Giret",
+        "Antoine Dechaume"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 236027359,
+            "url": "https://dl.afpy.org/pycon-fr-23//Jean-Christophe%20Giret%20-%20GEMSEO%20une%20biblioth%C3%A8que%20pour%20l%27optimisation%20multi-disciplinaire.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Garder-le-controle-de-ses-donnees-geolocalisees-avant-de-les-partager.json
+++ b/pycon-fr-2023/Garder-le-controle-de-ses-donnees-geolocalisees-avant-de-les-partager.json
@@ -1,0 +1,17 @@
+{
+    "title": "Garder le contr\u00f4le de ses donn\u00e9es g\u00e9olocalis\u00e9es avant de les partager",
+    "description": "Strava, runkeeper, runtastic, \u2026 sont des r\u00e9seaux sociaux pour les activit\u00e9s sportives bas\u00e9 sur l'usage de grandes quantit\u00e9 de donn\u00e9es g\u00e9olocalis\u00e9s pour fournir en retour divers services.\n\nLe fonctionnement par d\u00e9faut ne permet pas facilement de limiter les donn\u00e9es transmises et le co\u00fbt d'usage en donn\u00e9es personnel devient tr\u00e8s vite \u00e9lev\u00e9 si on n'utilise pas la totalit\u00e9 des services propos\u00e9.\n\nJ'ai souhait\u00e9 construire un outil qui permettrait de choisir les donn\u00e9es que je transmet, me permettant de b\u00e9n\u00e9ficier des quelques services de mon choix en limitant les donn\u00e9es utilis\u00e9 par les services qui ne m'int\u00e9ressent pas.\n\nC'est un projet exp\u00e9rimental et ouvert qui permet de mettre en lumi\u00e8re l\u2019\u00e9conomie de la donn\u00e9e des grands services en ligne.",
+    "duration": 1854,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Fred"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 206439784,
+            "url": "https://dl.afpy.org/pycon-fr-23//Fred%20-%20Garder%20le%20contr%C3%B4le%20de%20ses%20donn%C3%A9es%20g%C3%A9olocalis%C3%A9es%20avant%20de%20les%20partager.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Geographic-visualization-using-Streamlit.json
+++ b/pycon-fr-2023/Geographic-visualization-using-Streamlit.json
@@ -1,0 +1,17 @@
+{
+    "title": "Geographic visualization using Streamlit",
+    "description": "Among the plethora of libraries available in Python, I would like to discuss with you about\nsome of the capabilities of the Streamlit library towards geographic data visualization.\nUsing Streamlit we can create standalone web-apps. And here I want to show you how I\ngot to make Streamlit apps where the user could choose between different treatment/function to\napply :\n\n- interacting with the OSM database, (OSMNX)\n- extracting the content of the OSM database in a specific area described by a Polygon\ninteractively (OSMNX),\n- filtering the results during and after the request (OSMNX, (Geo)pandas) with regard\nto the location, or any other attribute,\n- etc...\n\nAfter treatment of the spatial data you could also do statistics on attributes, or display it\non a map using different libraries to display different types of diagrams and maps. All these repre-\nsentations having parameters that can be dynamically customized by \u00ab non-dev \u00bb people through\nthe Streamlit app, such as :\n\n- the color map,\n- the variable displayed,\n- the boundary shown on the graph,\n- the animation time\n- etc...\n\nI\u2019ll show what I thought I could do with it and how I did it and maybe we could discuss\nother means or ideas...",
+    "duration": 1970,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Micka\u00ebl Carlos"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 263942467,
+            "url": "https://dl.afpy.org/pycon-fr-23//Micka%C3%ABl%20Carlos%20-%20Geographic%20visualization%20using%20Streamlit.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Giving-and-receiving-great-feedback-through-PRs.json
+++ b/pycon-fr-2023/Giving-and-receiving-great-feedback-through-PRs.json
@@ -1,0 +1,17 @@
+{
+    "title": "Giving and receiving great feedback through PRs",
+    "description": "Do you struggle with PRs? Have you ever had to change code even though you disagreed with the change just to land the PR? Have you ever given feedback that would have improved the code only to get into a comment war? We'll discuss how to give and receive feedback to extract maximum value from it and avoid all the communication problems that come with PRs. We'll start with some thoughts about what PRs are intended to achieve and then first discuss how to give feedback that will be well received and result in improvements to the code followed by how to extract maximum value from feedback you receive without agreeing to suboptimal changes. Finally, we will look at a checklist for giving and receiving feedback you can use as you go through reviews both as an author and reviewer.",
+    "duration": 1985,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "David Andersson"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 1902805808,
+            "url": "https://dl.afpy.org/pycon-fr-23//David%20Andersson%20-%20Giving%20and%20receiving%20great%20feedback%20through%20PRs.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Interactive-HoloViz-Visualization-and-Dashboards.json
+++ b/pycon-fr-2023/Interactive-HoloViz-Visualization-and-Dashboards.json
@@ -1,0 +1,17 @@
+{
+    "title": "Interactive HoloViz Visualization and Dashboards",
+    "description": "Are you a data scientists who use data visualization to understand data and tell stories? Are you interested in building interactive plots and dashboards in Jupyter Notebook? HoloViz is a high-level Python visualization ecosystem that gives you the superpower to visualize easily even for big and multidimensional data, build visualizations for streaming data, turn nearly any notebook into a deployable dashboard, and help deploy your dashboards with the help of WebAssembly.",
+    "duration": 1857,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Sophia Yang"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 1771913254,
+            "url": "https://dl.afpy.org/pycon-fr-23//Sophia%20Yang%20-%20Interactive%20HoloViz%20Visualization%20and%20dashboards.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Interactive-web-pages-with-Django-or-Flask,-without-writing-JavaScript.json
+++ b/pycon-fr-2023/Interactive-web-pages-with-Django-or-Flask,-without-writing-JavaScript.json
@@ -1,0 +1,17 @@
+{
+    "title": "Interactive web pages with Django or Flask, without writing JavaScript",
+    "description": "Python has many excellent back-end frameworks, but we can't use it yet for mainstream front-end development. How do we bring our web pages to life without having to write Javascript, and without learning a front end framework like React or AngularJS?\n\nThe htmx library uses simple tag attributes to add behaviour to HTML tags. It gives you access to AJAX, CSS Transitions, WebSockets and Server Sent Events directly in HTML for modern user interfaces.\n\nLearn how, without refreshing the page, you can: create, update and delete data; change the date range for a chart; drill down using a sequence of dropdowns; and create an interactive search box.\n\nDiscover how to use htmx with any Python web framework. The examples will mostly use Django, plus a single example of how to use the same ideas in Flask.\n\nYou will also see how to create an infinite scrolling page, a sortable drag and drop table, and more.",
+    "duration": 1542,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Coen de Groot"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 1427875544,
+            "url": "https://dl.afpy.org/pycon-fr-23//Coen%20de%20Groot%20-%20Interactive%20web%20pages%20with%20Django%20or%20Flask%2C%20without%20writing%20JavaScript.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Introduction-a-Devops-(le-vrai).json
+++ b/pycon-fr-2023/Introduction-a-Devops-(le-vrai).json
@@ -1,0 +1,17 @@
+{
+    "title": "Introduction \u00e0 Devops (le vrai)",
+    "description": "Devops, tout le monde en parle, tout le monde semble en faire. Mais est-ce que l\u2019on utilise ce terme correctement ?\nNous allons red\u00e9finir la base et qu'est-ce que c'est vraiment.\nCette conf\u00e9rence est faite pour vous si vous vous demandez ce qu'est un DevOps. Mais aussi si vous voyez des recrutements de \u201cdevops\u201d et pourquoi les recruteurs/RH se trompent. Bref, viens r\u00e9tablir la v\u00e9rit\u00e9 avec nous.",
+    "duration": 1387,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Nicolas Ledez"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 1192300127,
+            "url": "https://dl.afpy.org/pycon-fr-23//Nicolas%20Ledez%20-%20Introduction%20%C3%A0%20Devops%20%28le%20vrai%29.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Introduction-to-Sigstore:-cryptographic-signatures-made-easier.json
+++ b/pycon-fr-2023/Introduction-to-Sigstore:-cryptographic-signatures-made-easier.json
@@ -1,0 +1,17 @@
+{
+    "title": "Introduction to Sigstore: cryptographic signatures made easier",
+    "description": "The last few years have seen a significant raise in Supply Chain attacks targeting third party software used in larger projects. With the need for developers to attest of the integrity and provenance of their software dependencies, alternatives have emerged to make tracing software back to the source more accessible, without a need for specific knowledge of cryptographic protocols used for generating and verifying artifact signatures.\n\nProject Sigstore (https://www.sigstore.dev/) is a new standard for signing, verifying and protecting software. This talk will provide an introduction to Sigstore, explaining the different components the project is built upon and how developers can use it to sign and verify software artifacts (Python packages, container images...) in a secure way.\nNotably, Sigstore solves the issue of private key storage and management by implementing \"keyless\" signing, where users can generate ephemeral key pairs and sign an artifact using an identity provider such as GitHub, Microsoft or Google.\n\nThe focus of this talk will be on the efforts made by the Python community to adopt Sigstore, showing how it is used to sign CPython releases and with a demo of the new sigstore-python client developers can use to get started with securing their Python projects.",
+    "duration": 1975,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Maya Costantini"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 1574581204,
+            "url": "https://dl.afpy.org/pycon-fr-23//Maya%20Costantini%20-%20Introduction%20to%20Sigstore%20-%20Cryptographic%20signatures%20made%20easy.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/J'ai-hacke-ma-chaudiere-pour-avoir-un-thermostat!.json
+++ b/pycon-fr-2023/J'ai-hacke-ma-chaudiere-pour-avoir-un-thermostat!.json
@@ -1,0 +1,17 @@
+{
+    "title": "J'ai hack\u00e9 ma chaudi\u00e8re pour avoir un thermostat\u202f!",
+    "description": "D\u00e9velopp\u00e9 avec Anyblok, 2 Raspberry Pi et quelques services python !\n\nEn achetant ma nouvelle maison il y a 4 ans j'ai r\u00e9cup\u00e9r\u00e9 une vielle chaudi\u00e8re au fioul !\n\nObjectif avoir un thermostat pour arr\u00eater de chauffer inutilement la maison (en attendant de changer cette vielle chaudi\u00e8re) !\n\nRetour d exp\u00e9rience sur les choix d architectures et outils d\u00e9velopp\u00e9s !",
+    "duration": 1925,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Pierre Verkest"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 249877149,
+            "url": "https://dl.afpy.org/pycon-fr-23//Pierre%20Verkest%20-%20J%27ai%20hack%C3%A9%20ma%20chaudi%C3%A8re%20pour%20avoir%20un%20thermostat%20%21.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Je-suis-nulle!.json
+++ b/pycon-fr-2023/Je-suis-nulle!.json
@@ -1,0 +1,17 @@
+{
+    "title": "Je suis nul\u00b7le\u202f!",
+    "description": "Je ne sais rien faire de vraiment utile. Toutes les personnes que je c\u00f4toie sont bien meilleures que moi. C\u2019est pour cela que je n\u2019ai rien \u00e0 dire d\u2019int\u00e9ressant, et encore moins le talent pour faire une conf\u00e9rence. Si vous avez le sentiment d\u2019\u00eatre un peu comme moi, venez m\u2019aider\u202f!",
+    "duration": 1177,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Guillaume Ayoub"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 121928580,
+            "url": "https://dl.afpy.org/pycon-fr-23//Guillaume%20Ayoub%20-%20Je%20suis%20nul%C2%B7le%20%21.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Lutter-contre-le-dereglement-climatique-avec-Django.json
+++ b/pycon-fr-2023/Lutter-contre-le-dereglement-climatique-avec-Django.json
@@ -1,0 +1,17 @@
+{
+    "title": "Lutter contre le d\u00e9r\u00e9glement climatique avec Django",
+    "description": "Quel titre aguicheur, n'est-il pas ? Et bien pourtant c'est vrai.\n\nJ'aimerais vous pr\u00e9senter un projet qui nous tiens \u00e0 coeur : CANARI (pour Climate ANalysis for Agricultural Recommendations and Impacts), une application bient\u00f4t open-sourc\u00e9e qui a pour but de faciliter l'anticipation du d\u00e9r\u00e9glement climatique pour les acteurs du monde agricole.\n\nC'est le r\u00e9sultat du partenariat entre Solagro, sp\u00e9cialiste des questions agricoles et du changement climatique, et Makina Corpus, concepteur d'applications web open source, en s'appuyant sur l'utilisation des projections climatiques fournies par l'Institut Pierre Simon Laplace, sp\u00e9cialiste de la mod\u00e9lisation climatique, et l'unit\u00e9 MARS du JRC (centre de recherches de l'Union Europ\u00e9enne) impliqu\u00e9e sur les enjeux d'adaptations de l'agriculture. Tout \u00e7a notamment financ\u00e9 par l'ADEME et le minist\u00e8re de l'Agriculture.\n\nCette session sera ainsi destin\u00e9e \u00e0 vous donner de l'espoir sur ce monde qui change, et \u00e0 vous pr\u00e9senter la stack technique bas\u00e9e sur :\n\n - Django et Django Rest Framework\n - CDO et celery pour les calculs\n - VueJS, Bootstrap et Plotly pour l'interface\n\net surtout comment nous avons rapidement et habilement (?) transform\u00e9 les pre-requis m\u00e9tiers en une application simple et fonctionnelle.\n\nPour en savoir plus d'ici l\u00e0 https://canari-agri.fr/",
+    "duration": 1609,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "SebCorbin"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 1203561312,
+            "url": "https://dl.afpy.org/pycon-fr-23//SebCorbin%20-%20Lutter%20contre%20le%20d%C3%A9r%C3%A9glement%20climatique%20avec%20Django.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Monitorez-vos-applications-Python-(et-pas-uniquement-votre-infra).json
+++ b/pycon-fr-2023/Monitorez-vos-applications-Python-(et-pas-uniquement-votre-infra).json
@@ -1,0 +1,17 @@
+{
+    "title": "Monitorez vos applications Python (et pas uniquement votre infra)",
+    "description": "Savoir quand son infrastructure et son application ne fonctionnent pas est un des d\u00e9fi que l'on rencontre quand on exploite une application.\nLe monde du monitoring a \u00e9volu\u00e9 ces derni\u00e8res ann\u00e9es: Prometheus s'est impos\u00e9 comme un standard. Au del\u00e0 des m\u00e9triques de votre infrastructure, nous verrons comment instrumentaliser votre code avec les SDK de Prometheus et d'OpenTelemetry pour avoir des m\u00e9triques pertinentes pour vos applications.",
+    "duration": 1557,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Lionel Porcheron"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 219990137,
+            "url": "https://dl.afpy.org/pycon-fr-23//Lionel%20Porcheron%20-%20Monitorez%20vos%20applications%20Python%20%28et%20pas%20uniquement%20votre%20infra%29.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Monorepo-Python-avec-environnements-de-developpement-reproductibles-et-CI-scalable.json
+++ b/pycon-fr-2023/Monorepo-Python-avec-environnements-de-developpement-reproductibles-et-CI-scalable.json
@@ -1,0 +1,17 @@
+{
+    "title": "Monorepo Python avec environnements de d\u00e9veloppement reproductibles et CI scalable",
+    "description": "Cette ann\u00e9e j'ai \u00e9t\u00e9 charg\u00e9 de la mise en place d'un monorepo python dans une startup du domaine m\u00e9dical/machine learning. J'aimerais partager l'exp\u00e9rience acquise en pr\u00e9sentant le setup choisi, qui s'appuie sur pip, poetry, et pants; avec certains contraintes impos\u00e9es par des paquets de data science (pytorch). Dans cet expos\u00e9 je d\u00e9taillerai le setup initial du monorepo, la communication requise pour expliquer nos choix et faire passer notre exp\u00e9rience \u00e0 des \u00e9quipes pas toujours au point sur les meilleurs pratiques d'ing\u00e9ni\u00e9rie et de reproducibilit\u00e9, et mentionner l'importance de la motivation des choix techniques.\n\nEnfin mon expos\u00e9 comprendra une pr\u00e9sentation de notre utilisation de Pants (https://www.pantsbuild.org/) pour obtenir un CI modulaire et scalable, qui limite le boilerplate et supporte des usages locaux/CI similaires.",
+    "duration": 1842,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Cl\u00e9ment Hurlin"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 209154189,
+            "url": "https://dl.afpy.org/pycon-fr-23//Cl%C3%A9ment%20Hurlin%20-%20Monorepo%20Python%20avec%20environnements%20de%20d%C3%A9veloppement%20reproductibles%20et%20CI%20scalable.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Nua,-un-PaaS-open-source-en-Python-pour-l'auto-hebergement-de-vos-applications.json
+++ b/pycon-fr-2023/Nua,-un-PaaS-open-source-en-Python-pour-l'auto-hebergement-de-vos-applications.json
@@ -1,0 +1,17 @@
+{
+    "title": "Nua, un PaaS open source en Python pour l'auto-h\u00e9bergement de vos applications",
+    "description": "#### R\u00e9sum\u00e9\n\nNua est un projet de plateforme cloud open source lanc\u00e9 par Abilian en 2021. Il propose un PaaS (platform as a service) qui peut s'installer facilement sur des serveurs bare metal ou virtualis\u00e9s, et qui permet de faire tourner des applications web conteneuris\u00e9es, en g\u00e9rant leur cycle de vie, les ressources dont elles ont besoin (stockage, bases de donn\u00e9es, etc.), les droits d'acc\u00e8s des utilisateurs, les backups, le monitoring, les logs...\n\nNua permet de g\u00e9rer des applications issues d'un portefeuille applicatif (\"marketplace\"), i.e. packag\u00e9es et optimis\u00e9es par les d\u00e9veloppeurs de la plateforme (ou des tiers). Nua permet aussi de d\u00e9ployer des applications en cours de d\u00e9veloppement (d\u00e9mo / qualif / prod), y compris plusieurs instances d'une m\u00eame application, et y compris en d\u00e9ploiement automatique (exemple de use case: cr\u00e9er des instances de d\u00e9mo \u00e0 la demande de prospects, en optimisant la consommation de ressources).\n\nNua est bas\u00e9 sur les principaux standards du monde open source et du cloud: base de donn\u00e9es (Postgres, MySQL, Mongodb, Redis), stockage (S3), OCI, dockerfiles et buildpacks, LDAP et SSO, etc. Nua s'appuie actuellement sur Docker, mais permettra \u00e0 terme de d\u00e9ployer des applications dans d'autres environnements d'ex\u00e9cution (autres conteneurs, VMs classiques ou l\u00e9g\u00e8res, SlapOS...).\n\nDocumentation et code source:\n\n- https://nua.rocks\n- https://github.com/abilian/nua\n\n\n#### Plan de la pr\u00e9sentation\n\n- Vision et caract\u00e9ristiques principales du projet\n  - Simplification du packaging et du d\u00e9ploiement multi-instances,\n  - Auto-h\u00e9bergement, souverainet\u00e9 num\u00e9rique\n  - Architecture g\u00e9n\u00e9rale\n\n- Pourquoi python ?\n  - Un runtime python dans le container\n  - Un orchestrateur pilotant les containers\n  - R\u00e9utilisation de composants entre le packaging, l'ex\u00e9cution de scripts et l'orchestration\n\n- Exemples et d\u00e9mo\n  - Fichier de configuration (vue du packageur)\n  - D\u00e9ploiement de configurations (vue CLI de l'utilisateur)\n\n- Roadmap et comment contribuer\n\n#### Take-aways\n\n- Pour les d\u00e9veloppeurs / devops : comment Nua peut aider \u00e0 d\u00e9ployer rapidement des versions de dev en phase de dev / pr\u00e9prod / prod, et \u00e0 g\u00e9rer les contraintes de la production (backup, upgrades) ?\n- Pour les responsables informatiques: comment Nua permet de d\u00e9ployer et de g\u00e9rer facilement un portefeuille d'application Web open source (intranet / extranet / Web) ?\n- Pour les d\u00e9veloppeurs d'applications tierces: comment porter ses applications sous Nua?\n- Pour les contributeurs open source: quelle est la roadmap de Nua et comment y contribuer ?",
+    "duration": 1457,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Jerome Dumonteil"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 155588018,
+            "url": "https://dl.afpy.org/pycon-fr-23//Jerome%20Dumonteil%20-%20Nua%2C%20un%20PaaS%20open%20source%20en%20Python%20pour%20l%27auto-h%C3%A9bergement%20de%20vos%20applications.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/NucliaDB,-une-base-de-donnees-pour-le-machine-learning-et-les-donnees-non-structurees.json
+++ b/pycon-fr-2023/NucliaDB,-une-base-de-donnees-pour-le-machine-learning-et-les-donnees-non-structurees.json
@@ -1,0 +1,17 @@
+{
+    "title": "NucliaDB, une base de donn\u00e9es pour le machine learning et les donn\u00e9es non-structur\u00e9es",
+    "description": "NucliaDB (https://github.com/nuclia/nucliadb) est une nouvelle base de donn\u00e9es vectorielles con\u00e7ue pour \u00eatre utilis\u00e9e dans des applications de recherche s\u00e9mantique et de machine learning. Elle combine recherches full-text, fuzzy, s\u00e9mantique et par graphe de relations. Elle constitue le syst\u00e8me de stockage parfait pour des datasets et des sorties de mod\u00e8les de machine learning et de les rendre op\u00e9rationnels dans des applications r\u00e9elles.",
+    "duration": 1596,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "\u00c9ric Br\u00e9hault"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 191988871,
+            "url": "https://dl.afpy.org/pycon-fr-23//%C3%89ric%20Br%C3%A9hault%20-%20NucliaDB%2C%20une%20base%20de%20donn%C3%A9es%20pour%20le%20machine%20learning%20et%20les%20donn%C3%A9es%20non-structur%C3%A9es.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/On-a-teste-pour-vous...-methodologie,-outils.json
+++ b/pycon-fr-2023/On-a-teste-pour-vous...-methodologie,-outils.json
@@ -1,0 +1,17 @@
+{
+    "title": "On a test\u00e9 pour vous... m\u00e9thodologie, outils",
+    "description": "\u00ab\u202fTester c\u2019est douter\u202f\u00bb ? Viens donc me voir pour apprendre \u00e0 douter avec moi. Je te pr\u00e9senterai pourquoi et comment tester, avec diff\u00e9rents niveaux que l\u2019on peut mettre en place sur un projet.",
+    "duration": 1941,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Nicolas Ledez"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 1599782548,
+            "url": "https://dl.afpy.org/pycon-fr-23//Nicolas%20Ledez%20-%20On%20a%20test%C3%A9%20pour%20vous...%20m%C3%A9thodologie%2C%20outils.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Ou-il-est-question-de-gaufre-et-dinternet.json
+++ b/pycon-fr-2023/Ou-il-est-question-de-gaufre-et-dinternet.json
@@ -1,0 +1,17 @@
+{
+    "title": "O\u00f9 il est question de gaufre et d\u2019internet",
+    "description": "Bien que cr\u00e9\u00e9 apr\u00e8s le protocole http, Le protocole gopher a su s'imposer rapidement au d\u00e9but des ann\u00e9es 1990 avant de quasiment disparaitre, totalement submerg\u00e9 par le World Wide Web.\n\u00c0 la fois contraint et limit\u00e9, il n'a pas su s'adapter et \u00e9voluer \u00e0 temps bien que son utilisation fut simple d'acc\u00e8s et lui a permis de se diffuser rapidement. Certains le font d'ailleurs toujours vivre aujourd'hui.\n\nJe parlerai donc du serveur que j'ai \u00e9cris : pourquoi, comment, et quelle vision de l'avenir j'entrevois pour ce protocole fort sympathique et l'utilit\u00e9 qu'on peut y trouver, encore aujourd'hui.\n\nAucune connaissance n'est pr\u00e9-requise pour cette conf\u00e9rence.",
+    "duration": 2503,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Mindiell"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 270943559,
+            "url": "https://dl.afpy.org/pycon-fr-23//Mindiell%20-%20O%C3%B9%20il%20est%20question%20de%20gaufre%20et%20d%27internet.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Portage-Python-sur-Webassembly.json
+++ b/pycon-fr-2023/Portage-Python-sur-Webassembly.json
@@ -1,0 +1,18 @@
+{
+    "title": "Portage Python sur Webassembly",
+    "description": "Pour quoi, pour qui et comment ?\n\nMise en application avec mode texte, pygame et Harfang3D",
+    "duration": 3163,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Peny Paul",
+        "Fran\u00e7ois Gutherz"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 493851463,
+            "url": "https://dl.afpy.org/pycon-fr-23//Peny%20Paul%20%26%20Fran%C3%A7ois%20Gutherz%20-%20Portage%20Python%20sur%20Webassembly.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Psycopg,-troisieme-du-nom.json
+++ b/pycon-fr-2023/Psycopg,-troisieme-du-nom.json
@@ -1,0 +1,17 @@
+{
+    "title": "Psycopg, troisi\u00e8me du nom",
+    "description": "Psycopg, sans doute l'adaptateur PostgreSQL pour le langage Python le plus populaire, a r\u00e9cemment connu une nouvel \u00e9lan via une r\u00e9\u00e9criture compl\u00e8te : pourquoi et comment cette refonte a-t-elle eu lieu ? Et comment se situe Psycopg dans l'\u00e9cosyst\u00e8me aujourd'hui ?\n\nMais en fait, communiquer avec un serveur de bases de donn\u00e9es PostgreSQL, qu'est-ce que \u00e7a veut dire ?\n\nEn enfin, quoi de neuf dans Psycopg 3 ?\n\nNous tenterons de r\u00e9pondre \u00e0 ces diff\u00e9rentes questions qui traitent de sujets aussi divers que : le financement du logiciel libre et la conduite du changement ; le protocole client/serveur Postgres ; la programmation asynchrone, les performances, le typage statique ; et bien s\u00fbr la communaut\u00e9 Python !",
+    "duration": 2146,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Denis Laxalde"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 233041615,
+            "url": "https://dl.afpy.org/pycon-fr-23//Denis%20Laxalde%20-%20Psycopg%2C%20troisi%C3%A8me%20du%20nom.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/PyScript-for-data-science.json
+++ b/pycon-fr-2023/PyScript-for-data-science.json
@@ -1,0 +1,17 @@
+{
+    "title": "PyScript for data science",
+    "description": "Are you a data scientist or a developer who mostly uses Python? Are you jealous of developers who write Javascript code and build fancy websites in a browser? How nice would it be if we can write websites in Python? PyScript makes it possible! PyScript allows users to write Python in the browser. In this talk, I will introduce PyScript and discuss what does PyScript mean for data scientists, how PyScript might change the way data scientists work, and how PyScript can be incorporated into the data science workflow.",
+    "duration": 1479,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Sophia Yang"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 1267376784,
+            "url": "https://dl.afpy.org/pycon-fr-23//Sophia%20Yang%20-%20PyScript%20for%20data%20science.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Python-moderne-et-fonctionnel-pour-des-logiciels-robustes.json
+++ b/pycon-fr-2023/Python-moderne-et-fonctionnel-pour-des-logiciels-robustes.json
@@ -1,0 +1,17 @@
+{
+    "title": "Python moderne et fonctionnel pour des logiciels robustes",
+    "description": "Tweag est un acteur reconnu du monde de la programmation fonctionnel. Mais qu'est ce que la programmation fonctionnelle ? Pourquoi s'y int\u00e9resser ?\nGr\u00e2ce aux derni\u00e8res fonctionnalit\u00e9s ajout\u00e9es \u00e0 Python ainsi que le d\u00e9veloppement des v\u00e9rificateurs de types, il n'a jamais \u00e9t\u00e9 aussi facile de faire du bon Python qui passe \u00e0 l'\u00e9chelle !",
+    "duration": 3056,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Guillaume Desforges"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 2168267116,
+            "url": "https://dl.afpy.org/pycon-fr-23//Guillaume%20Desforges%20-%20Python%20moderne%20et%20fonctionnel%20pour%20des%20logiciels%20robustes.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Python-web-performance-101:-uncovering-the-root-causes.json
+++ b/pycon-fr-2023/Python-web-performance-101:-uncovering-the-root-causes.json
@@ -1,0 +1,17 @@
+{
+    "title": "Python web performance 101: uncovering the root causes",
+    "description": "Web engineers meet issues with performance with fast-growing or even maintaining existing products. It\u2019s always unexpected and we have limited time for decisions. With our hero, we meet real-faced RAM, CPU and IO problems and learn troubleshooting approaches to monolithic and distributed systems.\n\nWe try different existing tools from Python and the cloud ecosystem including, but not limited to: cProfile, yappi, memory-profiler and tracing.\n\nThis talk will be more focused on backend parts and designed for intermediate-level web engineers, but all skill levels are welcome.",
+    "duration": 1567,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Alex Ptakhin"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 1191412071,
+            "url": "https://dl.afpy.org/pycon-fr-23//Alex%20Ptakhin%20-%20Python%20web%20performance%20101%20uncovering%20the%20root%20causes.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/REX-analyse-antivirus-des-fichiers-de-la-plateforme-emplois-de-linclusion.json
+++ b/pycon-fr-2023/REX-analyse-antivirus-des-fichiers-de-la-plateforme-emplois-de-linclusion.json
@@ -1,0 +1,17 @@
+{
+    "title": "REX analyse antivirus des fichiers de la plateforme emplois de l\u2019inclusion",
+    "description": "500,000 fichiers \u00e0 (re)scanner tous les mois.\n\n- Calibration (mesure des perfs de ClamAV)\n- Contraintes principales, m\u00e9tiers (et historiques)\n- Premi\u00e8re tentative (scan des fichiers r\u00e9cents et scan mensuel de toute la base)\n- Seconde tentative (traitement par lots avec un choix intelligent des lots)\n- C\u00f4t\u00e9 infra ?\n- Aller plus loin ?\n    - Gestion des fichiers infect\u00e9s\n    - Et s\u2019il fallait scanner plus ?\n    - Comment faire mieux ?",
+    "duration": 1478,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Fran\u00e7ois Freitag"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 154366491,
+            "url": "https://dl.afpy.org/pycon-fr-23//Fran%C3%A7ois%20Freitag%20-%20REX%20analyse%20antivirus%20des%20fichiers%20de%20la%20plateforme%20emplois%20de%20l%27inclusion.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Reinventer-le-tour-du-monde-en-(beaucoup)-moins-de-80-jours.json
+++ b/pycon-fr-2023/Reinventer-le-tour-du-monde-en-(beaucoup)-moins-de-80-jours.json
@@ -1,0 +1,17 @@
+{
+    "title": "R\u00e9inventer le tour du monde en (beaucoup) moins de 80 jours",
+    "description": "Tout commence avec l'envie d'utiliser l'intelligence articifielle pour d\u00e9couvrir autrement l'oeuvre de Jule Vernes. Tr\u00e8s vite les id\u00e9es s'encha\u00eenent : ouvrir une page au hasard, en comprendre le contenu, retrouver le parcours des personnages, retranscrire l'ambiance de cette \u00e9tape...\n\nAinsi n\u00e9 Homem : au croisement de l'analyse d'images, du search, de la compr\u00e9hension automatique du langage et de la g\u00e9n\u00e9ration de contenu. Le tout sous forme d'application web.\n\nOpen-source et polymathe, Python \u00e9tait tout indiqu\u00e9 pour mener \u00e0 bien un tel projet. Au del\u00e0 de son caract\u00e8re ludique, Homem illustre  l'incroyable potentiel de ce langage pour utiliser l'intelligence artificielle au sein d'une application industrielle.\u00a0\u200b",
+    "duration": 1046,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "B\u00e9reng\u00e8re Mathieu"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 146476262,
+            "url": "https://dl.afpy.org/pycon-fr-23//B%C3%A9reng%C3%A8re%20Mathieu%20-%20R%C3%A9inventer%20le%20tour%20du%20monde%20en%20%28beaucoup%29%20moins%20de%2080%20jours.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Rejoignez-le-Fediverse,-ajoutez-ActivityPub-a-votre-site!.json
+++ b/pycon-fr-2023/Rejoignez-le-Fediverse,-ajoutez-ActivityPub-a-votre-site!.json
@@ -1,0 +1,17 @@
+{
+    "title": "Rejoignez le Fediverse, ajoutez ActivityPub \u00e0 votre site\u202f!",
+    "description": "En 2022, Elon Musk rach\u00e8te Twitter. S'ensuit une s\u00e9rie de d\u00e9cisions d\u00e9sastreuses amenant de nombreux internautes \u00e0 se r\u00e9fugier sur Mastodon, un r\u00e9seau social qui revendique ne pas \u00eatre \u00e0 vendre, et qui a la particularit\u00e9 d'\u00eatre distribu\u00e9 : le logiciel, publi\u00e9 sous licence libre, est install\u00e9 sur des serveurs administr\u00e9s par des volontaires, capables de communiquer entre eux gr\u00e2ce \u00e0 un protocole nomm\u00e9 ActivityPub\n\nCe protocole est par ailleurs \u00e9galement utilis\u00e9 par de plus en plus nombreux logiciels, comme Pixelfed (partage de photos), PeerTube (vid\u00e9os) ou Writely (blogs), ce qui les rend capables de communiquer entre eux, cr\u00e9ant le \"Fediverse\".\n\nDurant cette conf\u00e9rence, je vous expliquerai comment fonctionne ce protocole et comment l'impl\u00e9menter sur votre propre site.",
+    "duration": 1889,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "J\u00e9r\u00f4me Tanghe"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 1602874576,
+            "url": "https://dl.afpy.org/pycon-fr-23//J%C3%A9r%C3%B4me%20Tanghe%20-%20Rejoignez%20le%20Fediverse%2C%20ajoutez%20ActivityPub%20%C3%A0%20votre%20site%20%21.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Supercharging-Jupyter-notebooks-for-effective-storytelling.json
+++ b/pycon-fr-2023/Supercharging-Jupyter-notebooks-for-effective-storytelling.json
@@ -1,0 +1,17 @@
+{
+    "title": "Supercharging Jupyter notebooks for effective storytelling",
+    "description": "Jupyter notebook is a popular tool for data analysis, but once the analysis is complete, it can be challenging to share the insights in a presentable and accessible way.\n\nIn this talk, I will show you some practical steps to organise and present your results in a friendly way to your viewers. I will also demonstrate how to turn a Jupyter notebook (or just the selected cells in a notebook) into an interactive web app with a few lines of code.\n\nAll examples will be based on typical data analyses with open-source packages such as Datapane. You will walk away from this session with tips and code snippets to improve your own Jupyter notebooks straight away.",
+    "duration": 1636,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Jo-fai Chow"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 1286294125,
+            "url": "https://dl.afpy.org/pycon-fr-23//Jo-fai%20Chow%20-%20Supercharging%20Jupyter%20notebooks%20for%20effective%20storytelling.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/The-power-of-AWS-Chalice-for-quick-serverless-API-development-in-Python.json
+++ b/pycon-fr-2023/The-power-of-AWS-Chalice-for-quick-serverless-API-development-in-Python.json
@@ -1,0 +1,17 @@
+{
+    "title": "The power of AWS Chalice for quick serverless API development in Python",
+    "description": "The Serverless Framework enables us to create and deliver high-quality applications fast and easily without having to worry too much about setting up resources and configurations. AWS Chalice is a serverless Python framework that can help you launch your serverless application quickly. In this presentation, you will discover the key features of AWS Chalice and how it can be used to quickly write, build and deploy serverless applications in python.",
+    "duration": 880,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Namrata Kankaria"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 625642285,
+            "url": "https://dl.afpy.org/pycon-fr-23//Namrata%20Kankaria%20-%20The%20power%20of%20AWS%20Chalice%20fo%20quick%20serverless%20API%20development%20in%20Python.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Traitement-de-donnees-geographiques-avec-Rasterio,-NumPy,-Fiona-et-Shapely.json
+++ b/pycon-fr-2023/Traitement-de-donnees-geographiques-avec-Rasterio,-NumPy,-Fiona-et-Shapely.json
@@ -1,0 +1,17 @@
+{
+    "title": "Traitement de donn\u00e9es g\u00e9ographiques avec Rasterio, NumPy, Fiona et Shapely",
+    "description": "Dans le cadre d'un projet de traitement de donn\u00e9es sur les riques naturels, nous avons \u00e9t\u00e9 amen\u00e9s \u00e0 utiliser:\n\n- rasterio et fiona pour l'acc\u00e8s aux donn\u00e9es\n- numpy et shapely pour l'analyse des donn\u00e9es\n\nCette pr\u00e9sentation sera donc l'occasion de pr\u00e9senter :\n\n- les donn\u00e9es g\u00e9ographiques matricielles et vectorielles\n- ainsi que des biblioth\u00e8ques Python de haut niveau pour les exploiter.",
+    "duration": 1373,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Arnaud Morvan"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 186666315,
+            "url": "https://dl.afpy.org/pycon-fr-23//Arnaud%20Morvan%20-%20Traitement%20de%20donn%C3%A9es%20g%C3%A9ographiques%20avec%20Rasterio%2C%20NumPy%2C%20Fiona%20et%20Shapely.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Transformez-vos-algorithmes-de-donnees-IA-en-applications-web-completes-en-un-rien-de-temps-avec-Taipy.json
+++ b/pycon-fr-2023/Transformez-vos-algorithmes-de-donnees-IA-en-applications-web-completes-en-un-rien-de-temps-avec-Taipy.json
@@ -1,0 +1,17 @@
+{
+    "title": "Transformez vos algorithmes de donn\u00e9es/IA en applications web compl\u00e8tes en un rien de temps avec Taipy",
+    "description": "Dans l'\u00e9cosyst\u00e8me open source Python, de nombreux packages sont disponibles pour :\n\n- la construction de puissants algorithmes\n\n- la visualisation des donn\u00e9es\n\nMalgr\u00e9 cela, plus de 85 % des pilotes en science des donn\u00e9es restent pilotes et n'arrivent pas \u00e0 l'\u00e9tape de la production. Avec Taipy, les Data Scientists/d\u00e9veloppeurs Python pourront cr\u00e9er d'excellents pilotes ainsi que de superbes applications pr\u00eates pour la production pour les utilisateurs finaux.\n\nTaipy fournit deux modules ind\u00e9pendants : Taipy GUI et Taipy Core.\n\nDans cette conf\u00e9rence, nous montrerons comment :\n\n- Taipy-GUI permet de cr\u00e9er des applications web rapidement et facilement. Il va bien au-del\u00e0 des capacit\u00e9s de la pile graphique standard : Gradio, Streamlit, Dash, etc.\n\n- Taipy Core permet de g\u00e9rer diff\u00e9rents mod\u00e8les, fonctions et datas gr\u00e2ce \u00e0 un syst\u00e8me facile de pipelines et de sc\u00e9narios. Il est plus simple mais plus puissant que la pile back-end Python standard : Airflow, MLFlow, Luigi, etc.",
+    "duration": 1640,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Florian Jacta"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 240541742,
+            "url": "https://dl.afpy.org/pycon-fr-23//Florian%20Jacta%2C%20Vincent%20Gosselin%20-%20Transformez%20vos%20algos%20de%20donn%C3%A9es%20IA%20en%20applications%20web%20avec%20Taipy.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Trying-no-GIL-on-scientific-programming.json
+++ b/pycon-fr-2023/Trying-no-GIL-on-scientific-programming.json
@@ -1,0 +1,17 @@
+{
+    "title": "Trying no GIL on scientific programming",
+    "description": "In this talk, we will have a look at what is no-gil Python and how it may improve the performance of some scientific calculations. First of all, we will touch upon the background knowledge of the Python GIL, what is it and why it is needed. On the contrary, why it is stopping multi-threaded CPU processes to take advantage of multi-core machines.\n\nAfter that, we will have a look at no-gil Python, a fork of CPython 3.9 by Same Gross. How it provides an alternative to using Python with no GIL and demonstrates it could be the future of the newer versions of Python. With that, we will try out this version of Python in some popular yet calculation-heavy algorithms in scientific programming and data sciences e.g. PCA, clustering, categorization and data manipulation with Scikit-learn and Pandas. We will compare the performance of this no-gil version with the original standard CPython distribution.\n\nThis talk is for Pythonistas who have intermediate knowledge of Python and are interested in using Python for scientific programming or data science. It may shine some light on having a more efficient way of using Python in their tasks and interest in trying the no-gil version of Python.",
+    "duration": 1334,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Cheuk Ting Ho"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 980391943,
+            "url": "https://dl.afpy.org/pycon-fr-23//Cheuk%20Ting%20Ho%20-%20Trying%20no%20GIL%20on%20scientific%20programming.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Un-membre-tres-discret-de-la-famille-Jupyter-mais-pourtant-si-utile!.json
+++ b/pycon-fr-2023/Un-membre-tres-discret-de-la-famille-Jupyter-mais-pourtant-si-utile!.json
@@ -1,0 +1,17 @@
+{
+    "title": "Un membre tr\u00e8s discret de la famille Jupyter mais pourtant si utile\u202f!",
+    "description": "Si vous travaillez avec des donn\u00e9es en Python, vous connaissez tr\u00e8s certainement l\u2019\u00e9cosyst\u00e8me Jupyter avec les Jupyter Notebooks et Labs. Mais connaissez-vous les Jupyter Hubs ? Cet outil permet de g\u00e9rer plusieurs comptes utilisateurs de Jupyter Notebooks ou Labs. Comme il faut commencer de mani\u00e8re modeste, je vais plut\u00f4t vous parler du plus petit Jupyter Hub (the littlest Jupyter Hub ou TLJH pour les intimes). Tr\u00e8s simple \u00e0 d\u00e9ployer et \u00e0 utiliser, il est tr\u00e8s pratique \u00e0 utiliser dans le cadre de formations. Durant cette conf\u00e9rence, je vous pr\u00e9senterai le retour d'exp\u00e9rience de mes utilisations dans le cadre de formations.",
+    "duration": 1693,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Pierre-Loic Bayart"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 1231796865,
+            "url": "https://dl.afpy.org/pycon-fr-23//Pierre-Loic%20Bayart%20-%20Un%20membre%20tr%C3%A8s%20discret%20de%20la%20famille%20Jupyter%20mais%20pourtant%20si%20utile%20%21.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Uncovering-Pythons-surprises:-a-deep-dive-into-gotchas.json
+++ b/pycon-fr-2023/Uncovering-Pythons-surprises:-a-deep-dive-into-gotchas.json
@@ -1,0 +1,17 @@
+{
+    "title": "Uncovering Python\u2019s surprises: a deep dive into gotchas",
+    "description": "Are you a Python programmer looking to expand your understanding of the language? Join us for a discussion on some of Python's most counterintuitive examples. We'll delve into how these behaviors work under the hood and explore why they don't always behave as we expect. This talk is suitable for programmers of all levels who have a curious mind and enjoy learning.",
+    "duration": 1005,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Mia Baji\u0107"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 849354213,
+            "url": "https://dl.afpy.org/pycon-fr-23//Mia%20Baji%C4%87%20-%20Uncovering%20Python%27s%20surprises%20a%20deep%20dive%20into%20gotchas.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Une-bonne-quantite-de-Python-peut-elle-rendre-Firefox-moins-vulnerable-aux-supply-chain-attacks?.json
+++ b/pycon-fr-2023/Une-bonne-quantite-de-Python-peut-elle-rendre-Firefox-moins-vulnerable-aux-supply-chain-attacks?.json
@@ -1,0 +1,17 @@
+{
+    "title": "Une bonne quantit\u00e9 de Python peut-elle rendre Firefox moins vuln\u00e9rable aux supply chain attacks\u202f?",
+    "description": "La s\u00e9curit\u00e9 informatique, c\u2019est dur ! On doit :\n * \u00e9crire du code qui ne contient aucun exploit,\n * monitorer nos d\u00e9pendances (y compris les transitives),\n * \u00e9viter de faire fuiter des secrets,\n * utiliser une infrastructure dans laquelle on a confiance,\n * et plus encore !\n\nSi on n\u00e9glige un de ces points, on fait courir un risque \u00e0 nos utilisateurs. 3 de ces exemples peuvent \u00eatre regroup\u00e9s en un type de menace : les \u201csupply chain attacks\u201d, les attaques sur la cha\u00eene d\u2019approvisionnement. En d\u2019autres termes, les attaquants ne s\u2019en prennent pas \u00e0 votre produit en lui-m\u00eame, mais ils cherchent des vuln\u00e9rabilit\u00e9s sur ce qui entoure votre produit.\n\nIl y a plusieurs mani\u00e8res de pallier ce risque. Par exemple : une entreprise peut tout \u00e0 fait mettre en place une infrastructure priv\u00e9e pour builder, tester et d\u00e9ployer ses produits. Cependant, lorsqu\u2019il s\u2019agit de logiciel open source, on se doit de rendre public le plus de choses possibles.\n\nAu cours de cette pr\u00e9sentation, j\u2019aimerais vous montrer comment une bonne quantit\u00e9 de Python permet \u00e0 Mozilla de publiquement builder, tester et d\u00e9ployer Firefox. Tout ceci en ayant une confiance raisonnablement grande, pour dire que les binaires que Mozilla publie correspondent au code que les Mozilliens ont \u00e9crit.",
+    "duration": 1670,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Johan Lorenzo"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 207895986,
+            "url": "https://dl.afpy.org/pycon-fr-23//Johan%20Lorenzo%20-%20Python%20peut-il%20rendre%20Firefox%20moins%20vuln%C3%A9rable%20aux%20supply%20chain%20attacks.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/Writing-Great-Test-Documentation.json
+++ b/pycon-fr-2023/Writing-Great-Test-Documentation.json
@@ -1,0 +1,17 @@
+{
+    "title": "Writing Great Test Documentation",
+    "description": "Have you ever needed to understand a new project and started reading the tests only to find that you have no idea what the tests are doing? In this talk we will discuss how to write great test documentation to make this a thing of the past! Writing great test documentation as you are writing tests will improve your tests and help you and others reading the tests later. We will first look at why test documentation is important both when writing tests and for future readers, then look at a framework that helps give some structure to your test documentation. Next, we will look at a showcase of the flake8-test-docs tool that automates test documentation checks to ensure your documentation is great! Finally we briefly discuss how this framework would apply in more advanced cases, such as when you are using fixtures or parametrising tests.",
+    "duration": 1764,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "David Andersson"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 221134228,
+            "url": "https://dl.afpy.org/pycon-fr-23//David%20Andersson%20-%20Writing%20Great%20Test%20Documentation.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/ZFS:-un-stockage-fiable,-puissant-et-accessible..json
+++ b/pycon-fr-2023/ZFS:-un-stockage-fiable,-puissant-et-accessible..json
@@ -1,0 +1,17 @@
+{
+    "title": "ZFS: un stockage fiable, puissant et accessible.",
+    "description": "ZFS est un outil de stockage passionnant qui va au-del\u00e0 d'un syst\u00e8me de fichier.\nN\u00e9 au d\u00e9but des ann\u00e9es 2000 au sein de Sun Microsytems, ZFS est aujourd'hui d\u00e9velopp\u00e9 au travers du projet openZFS pour les noyaux Linux et freeBSD.\nCette pr\u00e9sentation vise \u00e0 partager cet outil pour vous donner envie de l'essayer.",
+    "duration": 3111,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Fred"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 328148319,
+            "url": "https://dl.afpy.org/pycon-fr-23//Fred%20-%20ZFS%20un%20stockage%20fiable%2C%20puissant%20et%20accessible.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/pip-install-malware.json
+++ b/pycon-fr-2023/pip-install-malware.json
@@ -1,0 +1,17 @@
+{
+    "title": "pip install malware",
+    "description": "pip install malware: it\u2019s that easy. Almost all projects depend on external packages, but did you know how easy it can be to install something nasty instead of the dependency you want? I'll be showing this live, as I make malware and infect my own computer with it during the talk!\n\nYou might remember classic typosquatting examples like goggle.com, but it\u2019s now common to see malicious code hidden in spoofed or otherwise fraudulent PyPI packages or nested dependencies. Malware developers can also use techniques like starjacking to appear legitimate, so these unpleasant packages become even more difficult to spot. It\u2019s estimated that over 3% of packages on PyPI could be using this technique.\n\nBy the end of this talk, you\u2019ll know how to protect yourself when installing and updating dependencies and you\u2019ll leave with a checklist to follow to help you stay safe in future.",
+    "duration": 1879,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Max Kahan"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 1341945101,
+            "url": "https://dl.afpy.org/pycon-fr-23//Max%20Kahan%20-%20Pip%20install%20malware.mp4"
+        }
+    ]
+}

--- a/pycon-fr-2023/sphinx-lint-un-linter-pour-ta-doc.json
+++ b/pycon-fr-2023/sphinx-lint-un-linter-pour-ta-doc.json
@@ -1,0 +1,17 @@
+{
+    "title": "sphinx-lint : un linter pour ta doc",
+    "description": "sphinx-lint est, comme son nom l'indique, un linter pour de la doc Sphinx r\u00e9dig\u00e9e en reStructuredText.\n\nR\u00e9diger du code \u2192 utiliser un `linter` sur son code.\nR\u00e9diger de la doc \u2192 utiliser un `linter` sur sa doc ?\n\nSon but : z\u00e9ro faux positifs, et rapide.\n\nCette conf\u00e9rence pr\u00e9sentera sphinx-lint sous diff\u00e9rents angles :\n\n- Pourquoi un nouveau linter pour la doc Sphinx ?\n- Mais au fait, comment c'est pars\u00e9 le reStructuredText ?\n- OK, vendu, comment \u00e7a s'utilise ?\n- Retours d'exp\u00e9riences de gros projets utilisant sphinx-lint.",
+    "duration": 1809,
+    "language": "fra",
+    "recorded": "2023-02-18",
+    "speakers": [
+        "Julien Palard"
+    ],
+    "videos": [
+        {
+            "type": "mp4",
+            "size": 189060336,
+            "url": "https://dl.afpy.org/pycon-fr-23//Julien%20Palard%20-%20sphinx-lint%20un%20linter%20pour%20ta%20doc.mp4"
+        }
+    ]
+}


### PR DESCRIPTION
This PR could be merged as is, it "just" misses videos from peertube (they are here: https://indymotion.fr/c/raffut_media/videos) but they can be added by another PR.

We could also add torrents files (on https://dl.afpy.org/pycon-fr-23/) but I don't think it's handled by pyvideo?