### PR TITLE
Add PyCon US 2022 videos

### DIFF
--- a/pycon-us-2022/category.json
+++ b/pycon-us-2022/category.json
@@ -1,0 +1,3 @@
+{
+  "title": "PyCon US 2022"
+}

--- a/pycon-us-2022/videos/charlas-alison-orellana-rios-reconocimiento-de-figuras-con-vision-artificial.json
+++ b/pycon-us-2022/videos/charlas-alison-orellana-rios-reconocimiento-de-figuras-con-vision-artificial.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Se ver\u00e1 la gesti\u00f3n de la librer\u00eda OpenCV para el procesamiento de im\u00e1genes, con la que ser\u00e1 posible seguir los pasos para identificar figuras y diferentes elementos mediante algoritmos de reconocimiento de im\u00e1genes aplicados a la determinaci\u00f3n de formas.\n\nVer\u00e1s el uso de OpenCV ya que esta librer\u00eda te permite codificar r\u00e1pidamente, ya que cuenta con una documentaci\u00f3n oficial con muchos ejemplos, que ayudan a entender cada algoritmo en el procesamiento de im\u00e1genes, los pasos y su c\u00f3digo para ver su uso o aplicaci\u00f3n. Para ello, solo requiere una instalaci\u00f3n, (que es r\u00e1pida) y su posterior importaci\u00f3n para comenzar a ver sus funciones.\n\nLa visi\u00f3n artificial puede ayudar a mejorar el procesamiento de datos gr\u00e1ficos en diferentes \u00e1reas, tales como: industria, control de calidad, conteo de grandes cantidades de materiales, separaci\u00f3n r\u00e1pida de elementos, aseguramiento de la calidad, salud, determinaci\u00f3n de \u00e1reas de inter\u00e9s y m\u00e1s, lo que permite mejorar el trabajo. y tiempos de producci\u00f3n, adem\u00e1s de facilitar el tratamiento sin necesidad de interacci\u00f3n humana, lo que puede mejorar los resultados.",
+  "duration": 1344,
+  "language": "spa",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Alison Orellana Rios"
+  ],
+  "tags": [
+    "charla"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/LEOtbVjRzpw/hqdefault.jpg",
+  "title": "Charlas - Alison Orellana Rios: Reconocimiento de figuras con Visio\u0301n Artificial",
+  "videos": [
+    {
+      "length": 1344,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=LEOtbVjRzpw"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/charlas-alison-orellana-rios-reconocimiento-de-figuras-con-vision-artificial.json
+++ b/pycon-us-2022/videos/charlas-alison-orellana-rios-reconocimiento-de-figuras-con-vision-artificial.json
@@ -17,7 +17,7 @@
     "charla"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/LEOtbVjRzpw/hqdefault.jpg",
-  "title": "Charlas - Alison Orellana Rios: Reconocimiento de figuras con Visio\u0301n Artificial",
+  "title": "Reconocimiento de figuras con Visio\u0301n Artificial",
   "videos": [
     {
       "length": 1344,

--- a/pycon-us-2022/videos/charlas-ana-cecilia-vieira-analisis-exploratorio-de-datos-abiertos-para-el-fortalecimiento-de.json
+++ b/pycon-us-2022/videos/charlas-ana-cecilia-vieira-analisis-exploratorio-de-datos-abiertos-para-el-fortalecimiento-de.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Ven a aprender acerca del an\u00e1lisis exploratorio de datos abiertos con las librer\u00edas m\u00e1s populares de Python para la ciencia de datos. Adem\u00e1s, conocer el nivel de transparencia de datos en Am\u00e9rica Latina.\nLa charla va dirigida a las personas que tienen inter\u00e9s en el tema \u201cciencia de datos\u201d e iniciaron sus estudios, sin embargo a\u00fan no comprenden c\u00f3mo usarlos. Ser\u00e1n usadas las librer\u00edas Pandas y Matplotlib en el an\u00e1lisis, que ser\u00e1 hecho en el Google Collab.",
+  "duration": 1865,
+  "language": "spa",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Ana Cec\u00edlia Vieira"
+  ],
+  "tags": [
+    "charla"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/AXQ7cFm9WLI/maxresdefault.jpg",
+  "title": "Charlas - Ana Cec\u00edlia Vieira: Ana\u0301lisis exploratorio de datos abiertos para el fortalecimiento de...",
+  "videos": [
+    {
+      "length": 1865,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=AXQ7cFm9WLI"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/charlas-ana-cecilia-vieira-analisis-exploratorio-de-datos-abiertos-para-el-fortalecimiento-de.json
+++ b/pycon-us-2022/videos/charlas-ana-cecilia-vieira-analisis-exploratorio-de-datos-abiertos-para-el-fortalecimiento-de.json
@@ -17,7 +17,7 @@
     "charla"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/AXQ7cFm9WLI/maxresdefault.jpg",
-  "title": "Charlas - Ana Cec\u00edlia Vieira: Ana\u0301lisis exploratorio de datos abiertos para el fortalecimiento de...",
+  "title": "An\u00e1lisis exploratorio de datos abiertos para el fortalecimiento de democracias",
   "videos": [
     {
       "length": 1865,

--- a/pycon-us-2022/videos/charlas-andres-pineda-programacion-reactiva-navegando-en-el-mundo-de-la-asincronia-con-rxpy.json
+++ b/pycon-us-2022/videos/charlas-andres-pineda-programacion-reactiva-navegando-en-el-mundo-de-la-asincronia-con-rxpy.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "A medida que nuestras aplicaciones van creciendo y estas se van poniendo m\u00e1s complejas, el performance pudiera verse impactado por las diferentes tareas que se ejecutan, algunas inclusive llegando a bloquear el \u201cthread\u201d donde estas est\u00e1n corriendo.\n\nLa programaci\u00f3n reactiva (ReactiveX) nos ayuda con esto, permiti\u00e9ndonos escribir de una forma f\u00e1cil instrucciones que se ejecutar\u00e1n de forma as\u00edncrona gracias a los operadores que pueden ser usados para crear, filtrar y unificar los diferentes flujos de datos de nuestro sistema, todo esto, manteniendo nuestro c\u00f3digo flexible, legible y f\u00e1cil de mantener.\n\nEsta presentaci\u00f3n nos muestra que es la programaci\u00f3n reactiva, en qu\u00e9 consiste y que nos permite hacer para nuestros programas Python puedan implementarla y as\u00ed disfrutar de sus beneficios.",
+  "duration": 2067,
+  "language": "spa",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Andres Pineda"
+  ],
+  "tags": [
+    "charla"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/vET6Y2TFfXU/maxresdefault.jpg",
+  "title": "Charlas - Andres Pineda: Programacion Reactiva  Navegando en el mundo de la asincronia con RxPy",
+  "videos": [
+    {
+      "length": 2067,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=vET6Y2TFfXU"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/charlas-andres-pineda-programacion-reactiva-navegando-en-el-mundo-de-la-asincronia-con-rxpy.json
+++ b/pycon-us-2022/videos/charlas-andres-pineda-programacion-reactiva-navegando-en-el-mundo-de-la-asincronia-con-rxpy.json
@@ -17,7 +17,7 @@
     "charla"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/vET6Y2TFfXU/maxresdefault.jpg",
-  "title": "Charlas - Andres Pineda: Programacion Reactiva  Navegando en el mundo de la asincronia con RxPy",
+  "title": "Programacion Reactiva: Navegando en el mundo de la asincronia con RxPy",
   "videos": [
     {
       "length": 2067,

--- a/pycon-us-2022/videos/charlas-ariel-ortiz-match-case-para-principiantes.json
+++ b/pycon-us-2022/videos/charlas-ariel-ortiz-match-case-para-principiantes.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Python ha carecido durante mucho tiempo de un mecanismo de control de flujo condicional presente en muchos otros lenguajes de programaci\u00f3n, algo que permita tomar un valor y compararlo de manera directa y sencilla contra varias opciones. El lenguaje C y sus derivados cuentan con la instrucci\u00f3n switch/case. Otros lenguajes tienen un soporte m\u00e1s sofisticado de pattern matching. Las formas tradicionales para lograr un comportamiento equivalente en Python no eran del todo elegantes. Una opci\u00f3n era escribir una cadena de expresiones if/elif/else. Una segunda opci\u00f3n era utilizar un diccionario con llaves asociadas a funciones. En general esto funciona adecuadamente, pero puede ser complicado de construir, entender y mantener.\n\nDespu\u00e9s de varias propuestas fallidas para agregar una sintaxis tipo switch/case a Python, se acept\u00f3 finalmente una propuesta reciente para Python 3.10: structural pattern matching (b\u00fasquedas de coincidencias de patrones estructurales). Este esquema de pattern matching no solo hace posible realizar coincidencias simples de estilos de switch/case, sino que tambi\u00e9n admite una gama m\u00e1s amplia de casos de uso. En esta charla se mostrar\u00e1 c\u00f3mo aprovechar en nuestros programas esta nueva facilidad.",
+  "duration": 2495,
+  "language": "spa",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Ariel Ortiz"
+  ],
+  "tags": [
+    "charla"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/uCtcFi-L5PM/hqdefault.jpg",
+  "title": "Charlas - Ariel Ortiz: Match case para principiantes",
+  "videos": [
+    {
+      "length": 2495,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=uCtcFi-L5PM"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/charlas-ariel-ortiz-match-case-para-principiantes.json
+++ b/pycon-us-2022/videos/charlas-ariel-ortiz-match-case-para-principiantes.json
@@ -17,7 +17,7 @@
     "charla"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/uCtcFi-L5PM/hqdefault.jpg",
-  "title": "Charlas - Ariel Ortiz: Match case para principiantes",
+  "title": "Match case para principiantes",
   "videos": [
     {
       "length": 2495,

--- a/pycon-us-2022/videos/charlas-cristian-maureira-fredes-denny-perez-uniendo-a-las-comunidades-hispanohablantes-de-py.json
+++ b/pycon-us-2022/videos/charlas-cristian-maureira-fredes-denny-perez-uniendo-a-las-comunidades-hispanohablantes-de-py.json
@@ -1,0 +1,29 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Python en Espa\u00f1ol tiene como objetivo ser el lugar de encuentro central de todas las comunidades de Python hispanohablantes, ayudando a superar la barrera de lenguaje que usualmente es el primer problema con el que muchas personas se encuentran a la hora de buscar documentaci\u00f3n, experiencias, o consejos. El equipo de coordinaci\u00f3n est\u00e1 formado por personas de distintos pa\u00edses y comunidades, y busca poder tener representaci\u00f3n de cada pa\u00eds hispanohablante, y as\u00ed entender las distintas realidades a la que la comunidad se enfrenta.\nUno de los objetivos centrales, es poder compartir la informaci\u00f3n que la comunidad en general pueda aprender de la experiencia de todas las comunidades colectivamente, para que cada nuevo cap\u00edtulo se vaya formando sin tantas dificultades.\nFinalmente, la centralizaci\u00f3n de recursos y eventos, facilita el acceso para toda la comunidad.\n\nLuego de esta charla, aprender\u00e1s de los esfuerzos, proyectos e ideas detr\u00e1s de esta iniciativa, y sobre todo como poder sumarte.",
+  "duration": 1467,
+  "language": "spa",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Cristi\u00e1n Maureira-Fredes",
+    "Denny Perez"
+  ],
+  "tags": [
+    "charla"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/Vc0GW3nuODY/hqdefault.jpg",
+  "title": "Charlas - Cristi\u00e1n Maureira-Fredes/Denny Perez:  Uniendo a las comunidades hispanohablantes de Py...",
+  "videos": [
+    {
+      "length": 1467,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=Vc0GW3nuODY"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/charlas-cristian-maureira-fredes-denny-perez-uniendo-a-las-comunidades-hispanohablantes-de-py.json
+++ b/pycon-us-2022/videos/charlas-cristian-maureira-fredes-denny-perez-uniendo-a-las-comunidades-hispanohablantes-de-py.json
@@ -18,7 +18,7 @@
     "charla"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/Vc0GW3nuODY/hqdefault.jpg",
-  "title": "Charlas - Cristi\u00e1n Maureira-Fredes/Denny Perez:  Uniendo a las comunidades hispanohablantes de Py...",
+  "title": "Uniendo a las comunidades hispanohablantes de Python",
   "videos": [
     {
       "length": 1467,

--- a/pycon-us-2022/videos/charlas-debora-azevedo-software-educativo-que-es-como-se-hace.json
+++ b/pycon-us-2022/videos/charlas-debora-azevedo-software-educativo-que-es-como-se-hace.json
@@ -1,0 +1,32 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Si desea incursionar en la tecnolog\u00eda en la educaci\u00f3n, esta charla es para usted. Discutiremos las definiciones de tecnolog\u00eda y sus usos en la educaci\u00f3n como un medio para generar conocimiento y el desarrollo de software educativo y sus etapas. Para el desarrollo de esas herramientas es fundamental pensar en las concepciones pedag\u00f3gicas, que van a orientar todo el proceso de desarrollo. Posteriormente se presentar\u00e1n m\u00e1s detalles de cada etapa de desarrollo de este tipo de software, que son la concepci\u00f3n, elaboraci\u00f3n, finalizaci\u00f3n y viabilidad. En cada uno de ellos tambi\u00e9n se discutir\u00e1n procesos y patrones de buenas pr\u00e1cticas. Se presentar\u00e1 el software educativo que desarroll\u00e9 durante mi master, que tiene como objetivo ayudar a la alfabetizaci\u00f3n biling\u00fce (para lengua de signos brasile\u00f1a y portugu\u00e9s brasile\u00f1o escrito) de ni\u00f1os sordos siguiendo los patrones discutidos anteriormente. Terminaremos hablando de c\u00f3mo la innovaci\u00f3n debe estar presente en este tipo de herramientas, considerando la motivaci\u00f3n para desarrollar estas aplicaciones y los impactos que puede tener en la educaci\u00f3n. Finalmente, tambi\u00e9n discutiremos la accesibilidad y c\u00f3mo podr\u00eda haber problemas considerando nuestros propios prejuicios como desarrolladores de software, entre otras dificultades relacionadas con el proceso de desarrollo de software con fines educativos.",
+  "duration": 1655,
+  "language": "spa",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/128/2022-04-26T16%3A10%3A54.189378/PyCon_US_-_Charlas_2022.pdf"
+    }
+  ],
+  "speakers": [
+    "D\u00e9bora Azevedo"
+  ],
+  "tags": [
+    "charla"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/49MuQkgYiBs/hqdefault.jpg",
+  "title": "Charlas - D\u00e9bora Azevedo: Software educativo: \u00bfque es? \u00bfcomo se hace?",
+  "videos": [
+    {
+      "length": 1655,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=49MuQkgYiBs"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/charlas-debora-azevedo-software-educativo-que-es-como-se-hace.json
+++ b/pycon-us-2022/videos/charlas-debora-azevedo-software-educativo-que-es-como-se-hace.json
@@ -21,7 +21,7 @@
     "charla"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/49MuQkgYiBs/hqdefault.jpg",
-  "title": "Charlas - D\u00e9bora Azevedo: Software educativo: \u00bfque es? \u00bfcomo se hace?",
+  "title": "Software educativo: \u00bfque es? \u00bfcomo se hace?",
   "videos": [
     {
       "length": 1655,

--- a/pycon-us-2022/videos/charlas-kin-gutierrez-olivares-federico-garza-ramirez-nixtla-deep-learning-para-pronostico.json
+++ b/pycon-us-2022/videos/charlas-kin-gutierrez-olivares-federico-garza-ramirez-nixtla-deep-learning-para-pronostico.json
@@ -22,7 +22,7 @@
     "charla"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/O50p6ySOnm8/maxresdefault.jpg",
-  "title": "Charlas - Kin Gutierrez Olivares/Federico Garza Ramirez: Nixtla: Deep Learning para prono\u0301stico...",
+  "title": "Nixtla: Deep Learning para pron\u00f3stico de series de tiempo.",
   "videos": [
     {
       "length": 1703,

--- a/pycon-us-2022/videos/charlas-kin-gutierrez-olivares-federico-garza-ramirez-nixtla-deep-learning-para-pronostico.json
+++ b/pycon-us-2022/videos/charlas-kin-gutierrez-olivares-federico-garza-ramirez-nixtla-deep-learning-para-pronostico.json
@@ -1,0 +1,33 @@
+{
+  "copyright_text": "CC BY",
+  "description": "El pron\u00f3stico de series de tiempo tiene una amplia gama de aplicaciones: finanzas, retail, salud, IoT, etc. Recientemente modelos de deep learning como ESRNN o N-BEATS han demostrado tener performance estado del arte en estas tareas. Nixtlats es una librer\u00eda de python que hemos desarrollado para facilitar el uso de estos modelos estado del arte a data scientists y developers, para que puedan utilizarlos en ambientes productivos. Escrita en pytorch, su dise\u00f1o est\u00e1 enfocado en la usabilidad y reproducibilidad de los experimentos. Para ello, nixtlats cuenta con diversos m\u00f3dulos:\n\nData: contiene datasets de diversas competencias de series de tiempo.\nModels: incluye modelos estado del arte.\nEvaluation: posee diversas funciones de p\u00e9rdida y m\u00e9tricas de evaluaci\u00f3n.\n\nObjetivo:\n\n-Introducir a les asistentes a los retos del pron\u00f3stico de series de tiempo con deep learning.\n-Aplicaciones comerciales del pron\u00f3stico de series de tiempo.\n-Describir nixtlats, sus componentes y las mejores pr\u00e1cticas para entrenamiento y despliegue de modelos estado del arte en productivo.\n-Reproducci\u00f3n de resultados estado del arte usando nixtlats del modelo ganador de la competencia M4 de series de tiempo (ESRNN).",
+  "duration": 1703,
+  "language": "spa",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Repositorio del proyecto",
+      "url": "https://github.com/Nixtla/neuralforecast."
+    }
+  ],
+  "speakers": [
+    "Federico Garza Ramirez",
+    "Kin Gutierrez Olivares"
+  ],
+  "tags": [
+    "charla"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/O50p6ySOnm8/maxresdefault.jpg",
+  "title": "Charlas - Kin Gutierrez Olivares/Federico Garza Ramirez: Nixtla: Deep Learning para prono\u0301stico...",
+  "videos": [
+    {
+      "length": 1703,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=O50p6ySOnm8"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/charlas-laura-gutierrez-funderburk-reduciendo-prejuicio-en-la-inteligencia-artificial.json
+++ b/pycon-us-2022/videos/charlas-laura-gutierrez-funderburk-reduciendo-prejuicio-en-la-inteligencia-artificial.json
@@ -21,7 +21,7 @@
     "charla"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/xcz0Yk1OAzY/hqdefault.jpg",
-  "title": "Charlas - Laura Guti\u00e9rrez Funderburk: Reduciendo prejuicio en la inteligencia artificial...",
+  "title": "Reduciendo prejuicio en la inteligencia artificial: introducci\u00f3n a Fairlearn",
   "videos": [
     {
       "length": 1787,

--- a/pycon-us-2022/videos/charlas-laura-gutierrez-funderburk-reduciendo-prejuicio-en-la-inteligencia-artificial.json
+++ b/pycon-us-2022/videos/charlas-laura-gutierrez-funderburk-reduciendo-prejuicio-en-la-inteligencia-artificial.json
@@ -1,0 +1,32 @@
+{
+  "copyright_text": "CC BY",
+  "description": "En esta charla, el ponente proveer\u00e1:\n\n1. Introducci\u00f3n a un problema de aprendizaje autom\u00e1tico en el \u00e1mbito de salud: estudiaremos un problema con datos sobre pacientes, y un programa que busca recomendar a pacientes de mayor riesgo basado en el n\u00famero de visitas de emergencia y no emergencia.\n\n2. Ejemplos de c\u00f3mo evaluar los datos para identificar prejuicios utilizando gr\u00e1ficos y los paquetes pandas y matplolib. Entrenamiento del modelo con scikit-learn y evaluaci\u00f3n de eficacia de resultados.\n\n3. Una introducci\u00f3n a Fairlearn (https://fairlearn.org/). Basado en el ejemplo anterior, vamos a ver c\u00f3mo podemos utilizar Fairlearn para mejorar c\u00f3mo determina el algoritmo a qu\u00e9 pacientes recomendar via el uso de dos subm\u00f3ludos: MetricFrame y ThresholdOptimizer. Veremos c\u00f3mo podemos mejorar la calidad de las predicciones.\n\n4. C\u00f3mo aprender m\u00e1s sobre Fairlearn, la comunidad y oportunidades para contribuir.",
+  "duration": 1787,
+  "language": "spa",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "https://fairlearn.org/",
+      "url": "https://fairlearn.org/"
+    }
+  ],
+  "speakers": [
+    "Laura Guti\u00e9rrez Funderburk"
+  ],
+  "tags": [
+    "charla"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/xcz0Yk1OAzY/hqdefault.jpg",
+  "title": "Charlas - Laura Guti\u00e9rrez Funderburk: Reduciendo prejuicio en la inteligencia artificial...",
+  "videos": [
+    {
+      "length": 1787,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=xcz0Yk1OAzY"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/charlas-luis-conejo-de-cero-a-200-ok-en-30-minutos-desarrollo-web-con-django-heroku.json
+++ b/pycon-us-2022/videos/charlas-luis-conejo-de-cero-a-200-ok-en-30-minutos-desarrollo-web-con-django-heroku.json
@@ -17,7 +17,7 @@
     "charla"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/XBvBabYu_4c/hqdefault.jpg",
-  "title": "Charlas - Luis Conejo: De cero a 200 OK en 30 minutos  Desarrollo Web con Django, Heroku...",
+  "title": "De cero a 200 OK en 30 minutos: Desarrollo Web con Django, Heroku, TravisCI y GitHub",
   "videos": [
     {
       "length": 1779,

--- a/pycon-us-2022/videos/charlas-luis-conejo-de-cero-a-200-ok-en-30-minutos-desarrollo-web-con-django-heroku.json
+++ b/pycon-us-2022/videos/charlas-luis-conejo-de-cero-a-200-ok-en-30-minutos-desarrollo-web-con-django-heroku.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "En \u00e9poca reciente, tuve la oportunidad de desarrollar un proyecto de freelance con una empresa editorial cuyo objetivo es migrar su herramienta de generaci\u00f3n de libros de ser un script de Python, lanzado desde un terminal, a convertirse en una herramienta gr\u00e1fica basada en la web.\n\nEn el proceso, tuve la oportunidad de aplicar las herramientas para la creaci\u00f3n de una p\u00e1gina web completa que normalmente utilizo en mi trabajo como instructor de Python en una universidad.\n\nOBJETIVO\nEn esta charla, quiero compartir una versi\u00f3n simplificada de dicha experiencia, mostrando la creaci\u00f3n de un proyecto nuevo en Django, la implementaci\u00f3n de acceso controlado y de un modelo de base de datos en SQL, para finalmente desplegar nuestro proyecto en Heroku y habilitar Integraci\u00f3n Continua utilizando GitHub y TravisCI.\n\nEl proceso se desarrolla en su totalidad en el nivel de coste cero de cada servicio, mostrando que es posible crear un prototipo completo de esta manera.\n\nAUDIENCIA META\n\n- Desarrolladores interesados en hacer freelance en Python sin incurrir en altos costos para la creaci\u00f3n de un prototipo inicial para clientes potenciales.\n- Instructores interesados en ense\u00f1ar desarrollo web 100% en Python.\n- Desarrolladores que quieren aprender desarrollo web en Python.\n\nESTRUCTURA DE LA CHARLA\n\n- C\u00f3mo termin\u00e9 de desarrollador freelance? (3 minutos).\n- Las herramientas que utilizaremos (3 minutos).\n- Creando nuestro proyecto en Django (22 minutos).\n       - Configuraci\u00f3n inicial.\n       - Modelo de base de datos.\n       - La interfaz de administrador en Django.\n       - Plantillas HTML.\n       - Publicaci\u00f3n de nuestra p\u00e1gina en Heroku.\n       - Integraci\u00f3n Continua con GitHub y TravisCI.\n- Qu\u00e9 m\u00e1s podemos hacer? (2 minutos)",
+  "duration": 1779,
+  "language": "spa",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Luis Conejo"
+  ],
+  "tags": [
+    "charla"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/XBvBabYu_4c/hqdefault.jpg",
+  "title": "Charlas - Luis Conejo: De cero a 200 OK en 30 minutos  Desarrollo Web con Django, Heroku...",
+  "videos": [
+    {
+      "length": 1779,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=XBvBabYu_4c"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/charlas-marcelo-elizeche-lando-ayudapy-org-de-proyecto-de-fin-de-semana-a-movimiento-ciudadan.json
+++ b/pycon-us-2022/videos/charlas-marcelo-elizeche-lando-ayudapy-org-de-proyecto-de-fin-de-semana-a-movimiento-ciudadan.json
@@ -17,9 +17,10 @@
     "charla"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/6GRR0twSREk/hqdefault.jpg",
-  "title": "Charlas - Marcelo Elizeche Land\u00f3: AyudaPy org  De proyecto de fin de semana a movimiento ciudadan...",
+  "title": "AyudaPy.org: De proyecto de fin de semana a movimiento ciudadano clave durante la pandemia",
   "videos": [
     {
+      "length": 2027,
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=6GRR0twSREk"
     }

--- a/pycon-us-2022/videos/charlas-marcelo-elizeche-lando-ayudapy-org-de-proyecto-de-fin-de-semana-a-movimiento-ciudadan.json
+++ b/pycon-us-2022/videos/charlas-marcelo-elizeche-lando-ayudapy-org-de-proyecto-de-fin-de-semana-a-movimiento-ciudadan.json
@@ -1,0 +1,27 @@
+{
+  "copyright_text": "CC BY",
+  "description": "La charla trata sobre el proyecto AyudaPy.org que empez\u00f3 como un experimento/proyecto de fin de semana y se transform\u00f3 en una fuerza social en Paraguay que en muchos casos supli\u00f3 la respuesta del estado, de sus or\u00edgenes, futuro y sobre los desaf\u00edos de convertirse de la noche a la ma\u00f1ana en project manager, mantainer y vocero de un proyecto Open Source replicado en varios pa\u00edses y sobre todo de sobrevivir al burnout de esta situaci\u00f3n.\n\nLas tecnolog\u00edas usadas en este proyecto: Python, Django, PostGIS, OpenStreet Maps\n\nLista de temas a tratar - Como nace y el ambiente de crisis social en el cual se gesto el proyecto - Proyecto de fin de semana, idea simple ejecutada en el tiempo correcto - Aceptaci\u00f3n del publico - De 1 developer a ~30 en tiempo record - Crecimiento exponencial y open source - La comunidad de voluntarios - Apoyo de la Cruz Roja - Carga emocional de un proyecto social y el burnout - Impacto del proyecto y forks en otros pa\u00edses - ~6k familias ayudadas - Lecciones aprendidas",
+  "duration": 2027,
+  "language": "spa",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Marcelo Elizeche Land\u00f3"
+  ],
+  "tags": [
+    "charla"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/6GRR0twSREk/hqdefault.jpg",
+  "title": "Charlas - Marcelo Elizeche Land\u00f3: AyudaPy org  De proyecto de fin de semana a movimiento ciudadan...",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=6GRR0twSREk"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/charlas-marco-carranza-estrategias-para-trabajar-con-datos-a-medida-que-estos-crecen.json
+++ b/pycon-us-2022/videos/charlas-marco-carranza-estrategias-para-trabajar-con-datos-a-medida-que-estos-crecen.json
@@ -21,7 +21,7 @@
     "charla"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/Ie-eftK1OiQ/maxresdefault.jpg",
-  "title": "Charlas - Marco Carranza: Estrategias para trabajar con datos a medida que estos crecen",
+  "title": "Estrategias para trabajar con datos a medida que estos crecen",
   "videos": [
     {
       "length": 1836,

--- a/pycon-us-2022/videos/charlas-marco-carranza-estrategias-para-trabajar-con-datos-a-medida-que-estos-crecen.json
+++ b/pycon-us-2022/videos/charlas-marco-carranza-estrategias-para-trabajar-con-datos-a-medida-que-estos-crecen.json
@@ -1,0 +1,32 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Note: Captions start at minute 1:55\nHoy en d\u00eda, los datos son cada vez m\u00e1s grandes, por lo que es casi imposible procesarlos en m\u00e1quinas de escritorio. Para resolver este problema, han surgido muchas tecnolog\u00edas para procesar todos datos utilizando m\u00faltiples cl\u00fasteres de computadoras. El desaf\u00edo es construir soluciones sobre estas tecnolog\u00edas, requiriendo dise\u00f1ar complejos pipelines de datos combinando m\u00faltiples tecnolog\u00edas.\n\nSin embargo, en algunos casos, no disponemos suficiente tiempo o recursos para aprender a usar y configurar una infraestructura completa para ejecutar un par de experimentos. Quiz\u00e1s seas un investigador con recursos muy limitados o una startup con un calendario apretado para lanzar un producto al mercado.\n\nEl objetivo de esta charla es presentar diversas estrategias para procesar la data a medida que esta crece y puede ser procesada con los recursos limitados de una sola m\u00e1quina o con el uso de clusters, utilizando tecnolog\u00edas como Pandas, Pyspark, Vaex y Modin.",
+  "duration": 1836,
+  "language": "spa",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/72/2022-04-30T18%3A48%3A44.034748/Pycon_2022_-_Estrategias_para_trabajar_ZInYxdm.pdf"
+    }
+  ],
+  "speakers": [
+    "Marco Carranza"
+  ],
+  "tags": [
+    "charla"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/Ie-eftK1OiQ/maxresdefault.jpg",
+  "title": "Charlas - Marco Carranza: Estrategias para trabajar con datos a medida que estos crecen",
+  "videos": [
+    {
+      "length": 1836,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=Ie-eftK1OiQ"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/charlas-maria-andrea-vignau-bailo-con-tu-sombra-patch-stub-mock.json
+++ b/pycon-us-2022/videos/charlas-maria-andrea-vignau-bailo-con-tu-sombra-patch-stub-mock.json
@@ -21,7 +21,7 @@
     "charla"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/bM8A_WOMLns/hqdefault.jpg",
-  "title": "Charlas - Mar\u00eda Andrea Vignau: Bailo con tu sombra: Patch, stub, mock",
+  "title": "Bailo con tu sombra: Patch, stub, mock",
   "videos": [
     {
       "length": 1612,

--- a/pycon-us-2022/videos/charlas-maria-andrea-vignau-bailo-con-tu-sombra-patch-stub-mock.json
+++ b/pycon-us-2022/videos/charlas-maria-andrea-vignau-bailo-con-tu-sombra-patch-stub-mock.json
@@ -1,0 +1,32 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Pretendo incentivar la creaci\u00f3n de tests,\n\n1. Su importancia, ayudando a identificar las razones por las que usar objetos simulados.\n2. como inyectar estos en el c\u00f3digo, usando patch y dependencia inversa.\n3. las ventajas y potencia de la librer\u00eda mock, magicmock ayudar a identificar los casos de uso de patch, como emplear asserts respecto de las llamadas al mock y la posibilidad de usarlo como wrapper.\n4. Cierro contando dos casos de bibliotecas muy populares para tesetar p\u00e1ginas web: vcr-pytest y moto. el uso de mocks y de stubs.",
+  "duration": 1612,
+  "language": "spa",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/19/2022-04-25T16%3A47%3A54.046603/Mocks_es.pdf"
+    }
+  ],
+  "speakers": [
+    "Mar\u00eda Andrea Vignau"
+  ],
+  "tags": [
+    "charla"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/bM8A_WOMLns/hqdefault.jpg",
+  "title": "Charlas - Mar\u00eda Andrea Vignau: Bailo con tu sombra: Patch, stub, mock",
+  "videos": [
+    {
+      "length": 1612,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=bM8A_WOMLns"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/charlas-nicole-franco-leon-algebra-de-mapas-en-python.json
+++ b/pycon-us-2022/videos/charlas-nicole-franco-leon-algebra-de-mapas-en-python.json
@@ -17,7 +17,7 @@
     "charla"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/b-K4Iv55csU/hqdefault.jpg",
-  "title": "Charlas - Nicole Franco Leon: \u00c1lgebra de Mapas en Python",
+  "title": "\u00c1lgebra de Mapas en Python",
   "videos": [
     {
       "length": 1032,

--- a/pycon-us-2022/videos/charlas-nicole-franco-leon-algebra-de-mapas-en-python.json
+++ b/pycon-us-2022/videos/charlas-nicole-franco-leon-algebra-de-mapas-en-python.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "\u00c1lgebra de mapas es un lenguaje de expresiones aritm\u00e9ticas que utilizan relaciones (operadores y\nfunciones) y variables que representan datos y valores espaciales para realizar an\u00e1lisis geogr\u00e1ficos mediante el modulo ArcPy. El \u00e1lgebra de mapas b\u00e1sicamente implica hacer matem\u00e1ticas con mapas.\n\nLa idea de utilizar datos geogr\u00e1ficos existentes para generar nuevos o simplemente extraer de ellos resultados cuantitativos, es una pr\u00e1ctica com\u00fan desde el mismo momento en que aparece la cartograf\u00eda moderna.\n\nEn esta charla tendremos una introducci\u00f3n al modulo de ArcPy, su configuraci\u00f3n en ArcGis, pasando luego por una mirada hol\u00edstica de todo el modulo desde sus operadores, operaciones, y funciones algebraicas, la creaci\u00f3n de expresiones complejas para el procesamiento de datos geoespaciales en determinada temporalidad, la preparaci\u00f3n de las capas y concluiremos con la generaci\u00f3n de mapas usando Python.\n\nSi te gustan la geograf\u00eda, la matem\u00e1tica y Python, esta charla es para ti.",
+  "duration": 1032,
+  "language": "spa",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Nicole Franco Leon"
+  ],
+  "tags": [
+    "charla"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/b-K4Iv55csU/hqdefault.jpg",
+  "title": "Charlas - Nicole Franco Leon: \u00c1lgebra de Mapas en Python",
+  "videos": [
+    {
+      "length": 1032,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=b-K4Iv55csU"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/charlas-renne-rocha-querido-diario-como-liberar-datos-oficiales-de-ciudades-brasilenas-con-py.json
+++ b/pycon-us-2022/videos/charlas-renne-rocha-querido-diario-como-liberar-datos-oficiales-de-ciudades-brasilenas-con-py.json
@@ -17,7 +17,7 @@
     "charla"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/WEZ8NeFgwIg/maxresdefault.jpg",
-  "title": "Charlas - Renne Rocha: Querido Diario: C\u00f3mo Liberar Datos Oficiales de Ciudades Brasile\u00f1as con Py...",
+  "title": "Querido Diario: c\u00f3mo liberar datos oficiales de ciudades brasile\u00f1as con Python",
   "videos": [
     {
       "length": 1688,

--- a/pycon-us-2022/videos/charlas-renne-rocha-querido-diario-como-liberar-datos-oficiales-de-ciudades-brasilenas-con-py.json
+++ b/pycon-us-2022/videos/charlas-renne-rocha-querido-diario-como-liberar-datos-oficiales-de-ciudades-brasilenas-con-py.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Los Diarios Oficiales son las principales formas de comunicaci\u00f3n entre la ciudadan\u00eda y el poder ejecutivo de una ciudad. En Brasil, por ley, todos los actos oficiales del gobierno deben publicarse en los Diarios. Sin embargo, no existe un est\u00e1ndar sobre como deben estar disponibles estas publicaciones. Entonces tenemos un escenario donde las 5570 ciudades brasile\u00f1as publican cada uno a su manera, generalmente utilizando formatos cerrados como PDF que dificultan la consulta y an\u00e1lisis de datos de forma automatizada.\n\nEl proyecto Querido Diario tiene como objetivo hacer m\u00e1s accesibles estos Diarios, facilitando la b\u00fasqueda y consulta de su contenido a trav\u00e9s de una p\u00e1gina de b\u00fasqueda, una API abierta y en el futuro con herramientas de an\u00e1lisis de contenido.\n\nEn esta charla se presentar\u00e1 todo el proceso, desde la extracci\u00f3n de datos de las p\u00e1ginas de los municipios (mediante data scraping usando el framework Scrapy), el almacenamiento y procesamiento de archivos PDF para permitir la b\u00fasqueda en su contenido (usando OCR), a la API y la p\u00e1gina de b\u00fasqueda, donde cualquier persona tiene acceso centralizado a los Diarios de todos los municipios.",
+  "duration": 1688,
+  "language": "spa",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Renne Rocha"
+  ],
+  "tags": [
+    "charla"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/WEZ8NeFgwIg/maxresdefault.jpg",
+  "title": "Charlas - Renne Rocha: Querido Diario: C\u00f3mo Liberar Datos Oficiales de Ciudades Brasile\u00f1as con Py...",
+  "videos": [
+    {
+      "length": 1688,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=WEZ8NeFgwIg"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/charlas-sofia-martin-ariel-ramos-liliana-hurtado-enzo-juarez-python-vps-jupyter-hub-notebook.json
+++ b/pycon-us-2022/videos/charlas-sofia-martin-ariel-ramos-liliana-hurtado-enzo-juarez-python-vps-jupyter-hub-notebook.json
@@ -40,7 +40,7 @@
     "charla"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/sq4t8HfIPec/maxresdefault.jpg",
-  "title": "Charlas - Sof\u00eda Martin/Ariel Ramos/Liliana Hurtado/Enzo Ju\u00e1rez: Python + VPS Jupyter HUB/Notebook...",
+  "title": "Python + VPS Jupyter HUB/Notebook, aprender, ense\u00f1ar, investigar, trabajar de manera colaborativa, remota y presencial",
   "videos": [
     {
       "length": 1716,

--- a/pycon-us-2022/videos/charlas-sofia-martin-ariel-ramos-liliana-hurtado-enzo-juarez-python-vps-jupyter-hub-notebook.json
+++ b/pycon-us-2022/videos/charlas-sofia-martin-ariel-ramos-liliana-hurtado-enzo-juarez-python-vps-jupyter-hub-notebook.json
@@ -1,0 +1,51 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Desde 2017 en el Norte Argentino, realizamos actividades con experiencias en tecnologia de impacto positivo para la sociedad, lo hacemos con las Comunidades Python Norte y Python Argentina. Ense\u00f1amos a los asistentes buenas practicas de uso en tecnologia y Software Open Source.\n\nCombinamos 3 componentes para lograr un ambiente de tecnologia seguro y practico en estas experiencias piloto educativas, de manera remota, durante la pandemia COVID19.\n\nLos 3 componentes:\n\n- Lenguaje de Programacion + Entorno de Trabajo + Infraestructura == Python + Project Jupyter + VPS (Jupyter HUB/Notebook).\n\nVPS == Servidor Privado Virtual (Virtual Private Server)\n\nTuvimos en cuenta los conocimientos tecnicos basicos de los interesados, entonces decidimos implementar/instalar en un VPS todos los componentes necesarios (Python + Librerias + Plugins de Jupyter + Widgets), asi ellos aprenden directamente.\n\nIniciamos con programacion, luego con experiencias piloto programando Jupyters Notebooks para ense\u00f1ar Matematicas, Fisica, Robotica, armamos los notebooks con lo justo y necesario de programacion, ayudandonos de Widgets y Graficas.\n\nA medida que avanzamos, armamos Jupyter Notebooks en materias de No Calculo.\n\nLogramos una buena practica y dinamica en la asistencia de aprendizaje en el uso del VPS y la ense\u00f1anza de conceptos de materias en las que logramos armar/programar Jupyter Notebooks.\n\nLos interesados fueron Docentes, Alumnos, Particulares.\n\nSe hizo de manera remota, tambien tuvimos experiencias en forma presencial.\n\nGeneramos nuestros notebook como recursos.\n\nTambien se pudo formar Jovenes Investigadores de la Universidad de Salta en disciplinas No relacionadas a Tecnologia.\n\nMaterials: \n\n- https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/10/2022-04-30T20%3A41%3A37.101675/01-PyconUS-Ariel-Iniciando-Jupyter-Widgets.pdf\n- https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/10/2022-04-30T19%3A20%3A02.141276/01-LILIANA-HURTADO.pdf\n- https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/10/2022-04-30T20%3A46%3A33.139948/QR-GITHUB-MEDIANO.png\n- https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/10/2022-04-30T20%3A41%3A54.521757/02-PyconUS-Sofia-Ejemplos.pdf",
+  "duration": 1716,
+  "language": "spa",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/10/2022-04-30T20%3A41%3A37.101675/01-PyconUS-Ariel-Iniciando-Jupyter-Widgets.pdf"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/10/2022-04-30T20%3A41%3A54.521757/02-PyconUS-Sofia-Ejemplos.pdf"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/10/2022-04-30T19%3A20%3A02.141276/01-LILIANA-HURTADO.pdf"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/10/2022-04-30T20%3A46%3A33.139948/QR-GITHUB-MEDIANO.png"
+    },
+    {
+      "label": "Repositorio del Proyecto",
+      "url": "https://github.com/entrerrianas/pyconus2022"
+    }
+  ],
+  "speakers": [
+    "Ariel Silvio Norberto Ramos",
+    "Enzo Jesus Juarez Velazquez",
+    "Liliana Hurtado",
+    "Sofia Martin"
+  ],
+  "tags": [
+    "charla"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/sq4t8HfIPec/maxresdefault.jpg",
+  "title": "Charlas - Sof\u00eda Martin/Ariel Ramos/Liliana Hurtado/Enzo Ju\u00e1rez: Python + VPS Jupyter HUB/Notebook...",
+  "videos": [
+    {
+      "length": 1716,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=sq4t8HfIPec"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/diversity-inclusion-workgroup.json
+++ b/pycon-us-2022/videos/diversity-inclusion-workgroup.json
@@ -16,7 +16,9 @@
     "Anthony Shaw",
     "Reuven Lerner"
   ],
-  "tags": [],
+  "tags": [
+    "Keynote"
+  ],
   "thumbnail_url": "https://i.ytimg.com/vi/WcbnJA2ah6U/hqdefault.jpg",
   "title": "Diversity & Inclusion Workgroup",
   "videos": [

--- a/pycon-us-2022/videos/diversity-inclusion-workgroup.json
+++ b/pycon-us-2022/videos/diversity-inclusion-workgroup.json
@@ -1,0 +1,29 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Diversity & Inclusion Workgroup Panel\nGeorgi Ker, Lorena Mesa, Anthony Shaw, Reuven Lerner",
+  "duration": 1225,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Georgi Ker",
+    "Lorena Mesa",
+    "Anthony Shaw",
+    "Reuven Lerner"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/WcbnJA2ah6U/hqdefault.jpg",
+  "title": "Diversity & Inclusion Workgroup",
+  "videos": [
+    {
+      "length": 1225,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=WcbnJA2ah6U"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/keynote-closing-mariatta.json
+++ b/pycon-us-2022/videos/keynote-closing-mariatta.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "PyCon US 2022 comes to a close!",
+  "duration": 1523,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Mariatta Wijaya"
+  ],
+  "tags": [
+    "Keynote"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/iOUtQyKBzLo/hqdefault.jpg",
+  "title": "Keynote - Closing: Mariatta",
+  "videos": [
+    {
+      "length": 1523,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=iOUtQyKBzLo"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/keynote-closing-mariatta.json
+++ b/pycon-us-2022/videos/keynote-closing-mariatta.json
@@ -17,7 +17,7 @@
     "Keynote"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/iOUtQyKBzLo/hqdefault.jpg",
-  "title": "Keynote - Closing: Mariatta",
+  "title": "Conference Closing",
   "videos": [
     {
       "length": 1523,

--- a/pycon-us-2022/videos/keynote-lukasz-langa.json
+++ b/pycon-us-2022/videos/keynote-lukasz-langa.json
@@ -1,0 +1,32 @@
+{
+  "copyright_text": "CC BY",
+  "description": "CPython Developer in Residence, Python 3.8 and 3.9 release manager, creator of Black, pianist, dad. \nambv on Github. \nOpinions his own.",
+  "duration": 2520,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "About Keynote Speakers",
+      "url": "https://us.pycon.org/2022/about/keynote-speakers/#\u0142ukasz"
+    }
+  ],
+  "speakers": [
+    "\u0141ukasz Langa"
+  ],
+  "tags": [
+    "Keynote"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/wbohVjhqg7c/hqdefault.jpg",
+  "title": "Keynote - \u0141ukasz Langa",
+  "videos": [
+    {
+      "length": 2520,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=wbohVjhqg7c"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/keynote-lukasz-langa.json
+++ b/pycon-us-2022/videos/keynote-lukasz-langa.json
@@ -21,7 +21,7 @@
     "Keynote"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/wbohVjhqg7c/hqdefault.jpg",
-  "title": "Keynote - \u0141ukasz Langa",
+  "title": "\u0141ukasz Langa",
   "videos": [
     {
       "length": 2520,

--- a/pycon-us-2022/videos/keynote-naomi-ceder.json
+++ b/pycon-us-2022/videos/keynote-naomi-ceder.json
@@ -21,7 +21,7 @@
     "Keynote"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/sFmwGQu0cQU/hqdefault.jpg",
-  "title": "Keynote - Naomi Ceder",
+  "title": "Naomi Ceder",
   "videos": [
     {
       "length": 2225,

--- a/pycon-us-2022/videos/keynote-naomi-ceder.json
+++ b/pycon-us-2022/videos/keynote-naomi-ceder.json
@@ -1,0 +1,32 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Naomi Ceder earned a Ph.D in Classics several decades ago, but switched from ancient human languages to computer languages sometime in the last century. Since 2001, she has been learning, teaching, writing about, and using Python.\n\nShe has attended every PyCon since the first one in 2003 and was one of the originators of the Poster Session, the Education Summit, the Intro to Sprints sessions, the PyCon Charlas, and the Hatchery.\n\nAn elected fellow of the Python Software Foundation, Naomi is the immediate past chair of its board of directors. She is also co-founder of Trans*Code and speaks internationally about Python as well as community, inclusion, and diversity in technology in general.\n\nThe author of The Quick Python Book and the Explore Python Fundamentals project series, she has also done corporate training in Python. In her spare time she enjoys sketching, knitting, and deep philosophical conversations with her dog.",
+  "duration": 2225,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "About Keynote Speakers",
+      "url": "https://us.pycon.org/2022/about/keynote-speakers/#naomi"
+    }
+  ],
+  "speakers": [
+    "Naomi Ceder"
+  ],
+  "tags": [
+    "Keynote"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/sFmwGQu0cQU/hqdefault.jpg",
+  "title": "Keynote - Naomi Ceder",
+  "videos": [
+    {
+      "length": 2225,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=sFmwGQu0cQU"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/keynote-peter-wang.json
+++ b/pycon-us-2022/videos/keynote-peter-wang.json
@@ -1,0 +1,32 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Peter Wang is the CEO and co-founder of Anaconda, and helped found the PyData conferences and global community. Prior to starting Anaconda, Peter worked as a professional scientific computing and visualization software engineer. He has extensive experience in software design and development across a broad range of areas, including 3D graphics, geophysics, large data simulation and visualization, financial risk modeling, and medical imaging. Peter holds a BA in Physics from Cornell University.",
+  "duration": 2306,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "About Keynote Speakers",
+      "url": "https://us.pycon.org/2022/about/keynote-speakers/#peter"
+    }
+  ],
+  "speakers": [
+    "Peter Wang"
+  ],
+  "tags": [
+    "Keynote"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/qKfkCY7cmBQ/hqdefault.jpg",
+  "title": "Keynote - Peter Wang",
+  "videos": [
+    {
+      "length": 2306,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=qKfkCY7cmBQ"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/keynote-peter-wang.json
+++ b/pycon-us-2022/videos/keynote-peter-wang.json
@@ -21,7 +21,7 @@
     "Keynote"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/qKfkCY7cmBQ/hqdefault.jpg",
-  "title": "Keynote - Peter Wang",
+  "title": "Peter Wang",
   "videos": [
     {
       "length": 2306,

--- a/pycon-us-2022/videos/keynote-python-software-foundation-update.json
+++ b/pycon-us-2022/videos/keynote-python-software-foundation-update.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "PSF community update by Deb Nicholson",
+  "duration": 867,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Deb Nicholson"
+  ],
+  "tags": [
+    "Keynote"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/nQq8d24eWmk/maxresdefault.jpg",
+  "title": "Keynote - Python Software Foundation Update",
+  "videos": [
+    {
+      "length": 867,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=nQq8d24eWmk"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/keynote-python-software-foundation-update.json
+++ b/pycon-us-2022/videos/keynote-python-software-foundation-update.json
@@ -17,7 +17,7 @@
     "Keynote"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/nQq8d24eWmk/maxresdefault.jpg",
-  "title": "Keynote - Python Software Foundation Update",
+  "title": "Python Software Foundation Community Update",
   "videos": [
     {
       "length": 867,

--- a/pycon-us-2022/videos/keynote-sara-issaoun.json
+++ b/pycon-us-2022/videos/keynote-sara-issaoun.json
@@ -21,7 +21,7 @@
     "Keynote"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/x6SWPjdxvEI/hqdefault.jpg",
-  "title": "Keynote - Sara Issaoun",
+  "title": "Sara Issaoun",
   "videos": [
     {
       "length": 2631,

--- a/pycon-us-2022/videos/keynote-sara-issaoun.json
+++ b/pycon-us-2022/videos/keynote-sara-issaoun.json
@@ -1,0 +1,32 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Sara Issaoun is a NASA Einstein Fellow and observational astronomer at the Center for Astrophysics | Harvard & Smithsonian. She is a member of the Event Horizon Telescope (EHT) collaboration, the global effort to image and study the environment close to supermassive black holes. Her research centers around the collection, calibration, and imaging of millimeter-wave radio observations of supermassive black holes. Supermassive black holes generate the highest energy processes in the known Universe, ejecting jets of plasma affecting galaxy environments on large scales, but their dynamics and emission mechanisms remain shrouded in mystery. She makes use of global networks of radio-telescopes to image and study the immediate surroundings of the supermassive black holes at the centers of our Galaxy and the galaxy M87.",
+  "duration": 2631,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "About Keynote Speakers",
+      "url": "https://us.pycon.org/2022/about/keynote-speakers/#sara"
+    }
+  ],
+  "speakers": [
+    "Sara Issaoun"
+  ],
+  "tags": [
+    "Keynote"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/x6SWPjdxvEI/hqdefault.jpg",
+  "title": "Keynote - Sara Issaoun",
+  "videos": [
+    {
+      "length": 2631,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=x6SWPjdxvEI"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/keynote-steering-council-panel.json
+++ b/pycon-us-2022/videos/keynote-steering-council-panel.json
@@ -25,7 +25,7 @@
     "Keynote"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/m2R5shF1pLc/hqdefault.jpg",
-  "title": "Keynote - Steering Council Panel",
+  "title": "Python Steering Council Panel",
   "videos": [
     {
       "length": 2534,

--- a/pycon-us-2022/videos/keynote-steering-council-panel.json
+++ b/pycon-us-2022/videos/keynote-steering-council-panel.json
@@ -1,0 +1,36 @@
+{
+  "copyright_text": "CC BY",
+  "description": "PYTHON STEERING COUNCIL\n\n- Pablo Galindo Salgado\n- Petr Viktorin *\n- Thomas Wouters\n- Gregory P. Smith\n- Brett Cannon *\n\nElected as prescribed in PEP 8016, the Python Steering Council is a 5-person committee that assumes a mandate to maintain the quality and stability of the Python language and CPython interpreter, improve the contributor experience, formalize and maintain a relationship between the Python core team and the PSF, establish decision making processes for Python Enhancement Proposals, seek consensus among contributors and the Python core team, and resolve decisions and disputes in decision making among the language.\n\nThis keynote will update the community on current and future initiatives. Additionally, the Steering Council will address community questions collected prior to the conference.",
+  "duration": 2534,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "About Keynote Speakers",
+      "url": "https://us.pycon.org/2022/about/keynote-speakers/#steering-council"
+    }
+  ],
+  "speakers": [
+    "Pablo Galindo Salgado",
+    "Petr Viktorin",
+    "Thomas Wouters",
+    "Gregory P. Smith",
+    "Brett Cannon"
+  ],
+  "tags": [
+    "Keynote"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/m2R5shF1pLc/hqdefault.jpg",
+  "title": "Keynote - Steering Council Panel",
+  "videos": [
+    {
+      "length": 2534,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=m2R5shF1pLc"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/lightning-talks-day-1.json
+++ b/pycon-us-2022/videos/lightning-talks-day-1.json
@@ -1,0 +1,39 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Lightning talks are a ~ 5 minutes long, on any topic of interest to other Python people. It doesn't have to be about something that you wrote, it can be something that you learned, or a technique you think other people will be interested in.\n\nSpeakers:\n\n- 00:50 - Sameer Wagh - Data Science without Data?                    \n- 2:25 - Cheuk Ting Ho - Cultural Shock - My 1st                            \n- 7:25 - \u0141ukasz Langa - COVARIANCE/CONTRAVARIENCE           \n- 11:45 - Seth M Larson - Truststore: OS trust stores in Python   \n- 15:50 - Pablo Galindo - Memray: hardcore memory profiling   \n- 20:17 - Graham Waters -The grief cycle, data security breaches, how we could code the future of America and the world           \n- 24:17 - Mason Egger - What is Synthetic Data                          \n- 29:55 - Sophia Yang - Holoviz                                                           \n- 34:00 - Shiray Lamba - Robyn; The fastest rust based python webframework server                                                            \n- 39:00 - Chris May - Three steps to elegant code                   \n- 43:50 - Chris Ariza - Getting to 100% coverage                            \n- 49:15 - Indra - Jupyter ML model to production ML as a service",
+  "duration": 3314,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Sameer Wagh",
+    "Cheuk Ting Ho",
+    "\u0141ukasz Langa",
+    "Seth M Larson",
+    "Pablo Galindo",
+    "Graham Waters",
+    "Mason Egger",
+    "Sophia Yang",
+    "Shiray Lamba",
+    "Chris May",
+    "Chris Ariza",
+    "Indra"
+  ],
+  "tags": [
+    "lightning talks"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/1IiL31tUEVk/maxresdefault.jpg",
+  "title": "Lightning Talks - Day 1",
+  "videos": [
+    {
+      "length": 3314,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=1IiL31tUEVk"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/lightning-talks-day-2-am.json
+++ b/pycon-us-2022/videos/lightning-talks-day-2-am.json
@@ -1,0 +1,37 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Lightning talks are a ~ 5 minutes long, on any topic of interest to other Python people. It doesn't have to be about something that you wrote, it can be something that you learned, or a technique you think other people will be interested in.\n\nSpeakers:\n\n- 00:45 - Jeff Weiss - Teaching Python for Community Outreach (Note: Video begins at ~2:40:00)\n- 06:16 - Jessica David - How staying away from one word can change everything\n- 10:59 - Roy m Mezan  - Biometric attack\n- 15:28 - Gajendra Deshpande - Security Considerations in Python Packaging\n- 20:32 - Diamond Bishop - Scaling PyTorch Models in Prod\n- 25:44 - Manabu Terada - Our Challeng to spread Python community w/ covid in Japan\n- 30:59 - Jay Miller - DevRel: showing your company skills\n- 36:29 - Jack Lee - Non-trivial applications of binary search\n- 41:11 - Henry Schreiner - Scikit-hep: developer pages a guide for modern package development\n- 46:44 - Chrisjrn - STOP RUNNING YOUR TESTS",
+  "duration": 3080,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Jeff Weiss",
+    "Jessica David",
+    "Roy m Mezan",
+    "Gajendra Deshpande",
+    "Diamond Bishop",
+    "Manabu Terada",
+    "Jay Miller",
+    "Jack Lee",
+    "Henry Schreiner",
+    "Chrisjrn"
+  ],
+  "tags": [
+    "lightning talks"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/r-rpo4Xm_lM/maxresdefault.jpg",
+  "title": "Lightning Talks - Day 2 AM",
+  "videos": [
+    {
+      "length": 3080,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=r-rpo4Xm_lM"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/lightning-talks-day-2-pm.json
+++ b/pycon-us-2022/videos/lightning-talks-day-2-pm.json
@@ -1,0 +1,38 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Lightning talks are a ~ 5 minutes long, on any topic of interest to other Python people. It doesn't have to be about something that you wrote, it can be something that you learned, or a technique you think other people will be interested in.\n\nSpeakers:\n\n- 00:35 - Christian Maureia Fredes - Python en Espanol\n- 05:35 - Mario Munoz - My First Pycon: Reflections\n- 10:20 - Georgi Ker - Open source is a walk in the park\n- 14:30 - Bence Nagy - Lint your code, repo, playlist, and fashion sense\n- 19:49 - Mark Shannon - Help us speed up Python with benchmarks\n- 23:35 - Larry Hastings - Correlate your data with Correlate\n- 27:39 - Rich Taggart - The importance of effective concise communication\n- 35:38 - William Woodruff - Securing your PyPI account\n- 40:18 - Alexa Lindberg - Generating recipes w/ GPT-2 & Python\n- 20:53 - Srinivas Bontula - Managing transitive dependencies for Django\n- 50:25 - Adrian - When to rewrite in rust",
+  "duration": 3327,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Christian Maureia Fredes",
+    "Mario Munoz",
+    "Georgi Ker",
+    "Bence Nagy",
+    "Mark Shannon",
+    "Larry Hastings",
+    "Rich Taggart",
+    "William Woodruff",
+    "Alexa Lindberg",
+    "Srinivas Bontula",
+    "Adrian"
+  ],
+  "tags": [
+    "lightning talks"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/xQ0-aSmn9ZA/maxresdefault.jpg",
+  "title": "Lightning Talks - Day 2 PM",
+  "videos": [
+    {
+      "length": 3327,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=xQ0-aSmn9ZA"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/lightning-talks-day-3.json
+++ b/pycon-us-2022/videos/lightning-talks-day-3.json
@@ -1,0 +1,35 @@
+{
+  "copyright_text": null,
+  "description": "Lightning talks are a ~ 5 minutes long, on any topic of interest to other Python people. It doesn't have to be about something that you wrote, it can be something that you learned, or a technique you think other people will be interested in.\n\nSpeakers:\n\n- 00:23 - Pandy Knight - How to write a test case\n- 05:09 - Shreya Batra - The Effects of Computational THinking\n- 09:36 - Patrick Arminio - The fastest way to fetch the latest python version\n- 11:57 - Ray McLendon - Not all data is created equal\n- 16:24 - Geir Arne Hjelle - Reading PEPs\n- 21:30 - Jonathan Helmus - Pip install Python?\n- 26:07 - Jelle Zijlstra - PEP 688: Typing for the buffer protocol\n- 29:30 - Nick Muoh - Post pandemic meetuup\n- 33:25 - multiple speakers talking about Regional Python Conferences",
+  "duration": 2378,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Pandy Knight",
+    "Shreya Batra",
+    "Patrick Arminio",
+    "Ray McLendon",
+    "Geir Arne Hjelle",
+    "Jonathan Helmus",
+    "Jelle Zijlstra",
+    "Nick Muoh"
+  ],
+  "tags": [
+    "lightning talks"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/tF5SD-JlGo4/maxresdefault.jpg",
+  "title": "Lightning Talks - Day 3",
+  "videos": [
+    {
+      "length": 2378,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=tF5SD-JlGo4"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-a-jesse-jiryu-davis-why-should-async-get-all-the-love-advanced-control-flow-with-threads.json
+++ b/pycon-us-2022/videos/talk-a-jesse-jiryu-davis-why-should-async-get-all-the-love-advanced-control-flow-with-threads.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/DgjO5nSxp0I/maxresdefault.jpg",
-  "title": "Talk - A. Jesse Jiryu Davis: Why Should Async Get All The Love?: Advanced Control Flow With Threads",
+  "title": "Why Should Async Get All The Love?: Advanced Control Flow With Threads",
   "videos": [
     {
       "length": 1656,

--- a/pycon-us-2022/videos/talk-a-jesse-jiryu-davis-why-should-async-get-all-the-love-advanced-control-flow-with-threads.json
+++ b/pycon-us-2022/videos/talk-a-jesse-jiryu-davis-why-should-async-get-all-the-love-advanced-control-flow-with-threads.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "asyncio introduced many of us to futures, chaining, fan-out and fan-in, cancellation tokens, and other advanced control flow concepts. But Python threads were doing this stuff before it was cool! Come see Python threading techniques inspired by asyncio, Go, and Node.",
+  "duration": 1656,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "A. Jesse Jiryu Davis"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/DgjO5nSxp0I/maxresdefault.jpg",
+  "title": "Talk - A. Jesse Jiryu Davis: Why Should Async Get All The Love?: Advanced Control Flow With Threads",
+  "videos": [
+    {
+      "length": 1656,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=DgjO5nSxp0I"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-aaron-stephens-python-for-threat-intelligence.json
+++ b/pycon-us-2022/videos/talk-aaron-stephens-python-for-threat-intelligence.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "BY CC",
+  "description": "For many of us, writing code isn't our job - but we do it anyways. We're not software engineers, and balancing the two isn't easy, but we make do. Because with just a few lines of Python, we can automate the boring, tedious work and enable ourselves to tackle the really hard problems. This is especially true in threat intelligence, where analysts help defenders make informed decisions to protect themselves and their businesses against the security incidents happening every single day.\n\nHow do major hacks happen, who's responsible, and why? Come and learn about the world of threat intelligence, why we ask these questions, how we answer them, and - most importantly - the Python tools we've built along the way. See how we approach development on a team without any developers, balance process with productivity and enable success at scale. This one is for all the scripts out there helping us do our jobs, and for all the part-time developers who write them. Enjoy!",
+  "duration": 1361,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Aaron Stephens"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/Zf38qncahiU/hqdefault.jpg",
+  "title": "Talk - Aaron Stephens: Python for Threat Intelligence",
+  "videos": [
+    {
+      "length": 1361,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=Zf38qncahiU"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-aaron-stephens-python-for-threat-intelligence.json
+++ b/pycon-us-2022/videos/talk-aaron-stephens-python-for-threat-intelligence.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/Zf38qncahiU/hqdefault.jpg",
-  "title": "Talk - Aaron Stephens: Python for Threat Intelligence",
+  "title": "Python for Threat Intelligence",
   "videos": [
     {
       "length": 1361,

--- a/pycon-us-2022/videos/talk-ajinkya-rajput-ashish-bijlani-bad-actors-vs-our-community-detecting-software-supply-chain.json
+++ b/pycon-us-2022/videos/talk-ajinkya-rajput-ashish-bijlani-bad-actors-vs-our-community-detecting-software-supply-chain.json
@@ -20,7 +20,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/Rcuqn56uCDk/maxresdefault.jpg",
-  "title": "Talk - Ajinkya Rajput/Ashish Bijlani: Bad actors vs our community: detecting software supply chain...",
+  "title": "Bad actors vs our community: detecting software supply chain attacks on Python ecosystem",
   "videos": [
     {
       "length": 1528,

--- a/pycon-us-2022/videos/talk-ajinkya-rajput-ashish-bijlani-bad-actors-vs-our-community-detecting-software-supply-chain.json
+++ b/pycon-us-2022/videos/talk-ajinkya-rajput-ashish-bijlani-bad-actors-vs-our-community-detecting-software-supply-chain.json
@@ -1,0 +1,31 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Rapid prototyping or development is one of the most favourite features of the Python software ecosystem. This is possible due to efficient reuse of software libraries enabled by package managers such as PyPi. While PyPI maintainers have streamlined the process of publishing and distributing a package for developers, bad actors evidently exploit this infrastructure to propagate malware. For example, simply by publishing a malicious package with a name similar to a popular package, bad actors can exploit carelessness or inexperience of developers and elevate a simple installation typo to a remote code execution attack.\n\nIn this talk, we will present technical details of our large-scale vetting system that analyzes millions of published software package versions for malware and other \u201crisky\u201d attributes, such as sudo access, source inconsistencies, abandonware, and unsafe installation hooks. We will share our experience while building this system, and present examples of new malware we have detected as case studies. Finally, we will introduce our free tool OSSIE, a Python PyPi package, for developers to audit project dependencies and notify them when dependencies turn malicious. The presented tool is extremely user friendly and is an attempt towards furthering usable security.",
+  "duration": 1528,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/115/2022-04-30T23%3A12%3A58.090937/pycon22.pdf"
+    }
+  ],
+  "speakers": [
+    "Ajinkya Rajput",
+    "Ashish Bijlani"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/Rcuqn56uCDk/maxresdefault.jpg",
+  "title": "Talk - Ajinkya Rajput/Ashish Bijlani: Bad actors vs our community: detecting software supply chain...",
+  "videos": [
+    {
+      "length": 1528,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=Rcuqn56uCDk"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-amit-saha-implementing-shared-functionality-using-middleware.json
+++ b/pycon-us-2022/videos/talk-amit-saha-implementing-shared-functionality-using-middleware.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/_t7GxTbKocc/maxresdefault.jpg",
-  "title": "Talk - Amit Saha: Implementing shared functionality using Middleware",
+  "title": "Implementing shared functionality using Middleware",
   "videos": [
     {
       "length": 1544,

--- a/pycon-us-2022/videos/talk-amit-saha-implementing-shared-functionality-using-middleware.json
+++ b/pycon-us-2022/videos/talk-amit-saha-implementing-shared-functionality-using-middleware.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "In this talk, I will provide an introduction to the topic of writing middleware for your web applications. Middleware is often simply brought in to an application's code base, without perhaps a thorough understanding of how they work. This talk will shed light on how middleware components work in popular Python web frameworks - Flask, Django and FastAPI.\n\nArmed with that understanding, you will learn how to write your own middleware as well as use standard community contributed middleware to implement vital functionality in your applications.",
+  "duration": 1544,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/6/2022-04-29T03%3A09%3A30.428341/slides.pdf"
+    }
+  ],
+  "speakers": [
+    "Amit Saha"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/_t7GxTbKocc/maxresdefault.jpg",
+  "title": "Talk - Amit Saha: Implementing shared functionality using Middleware",
+  "videos": [
+    {
+      "length": 1544,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=_t7GxTbKocc"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-anthony-shaw-write-faster-python-common-performance-anti-patterns.json
+++ b/pycon-us-2022/videos/talk-anthony-shaw-write-faster-python-common-performance-anti-patterns.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "This talk will show small, specific examples of Python code that can be refactored to be faster without compromising on readability. At the start of the talk, I'll explain how to set up a profiler to measure application performance and how to track improvements and regressions.",
+  "duration": 1797,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Anthony Shaw"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/YY7yJHo0M5I/hqdefault.jpg",
+  "title": "Talk - Anthony Shaw: Write faster Python! Common performance anti patterns",
+  "videos": [
+    {
+      "length": 1797,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=YY7yJHo0M5I"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-anthony-shaw-write-faster-python-common-performance-anti-patterns.json
+++ b/pycon-us-2022/videos/talk-anthony-shaw-write-faster-python-common-performance-anti-patterns.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/YY7yJHo0M5I/hqdefault.jpg",
-  "title": "Talk - Anthony Shaw: Write faster Python! Common performance anti patterns",
+  "title": "Write faster Python! Common performance anti-patterns",
   "videos": [
     {
       "length": 1797,

--- a/pycon-us-2022/videos/talk-antoine-toubhans-flexible-ml-experiment-tracking-system-for-python-coders-with-dvc-and-st.json
+++ b/pycon-us-2022/videos/talk-antoine-toubhans-flexible-ml-experiment-tracking-system-for-python-coders-with-dvc-and-st.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/EGIzJIfAy7g/maxresdefault.jpg",
-  "title": "Talk - Antoine Toubhans: Flexible ML Experiment Tracking System for Python Coders with DVC and St...",
+  "title": "Flexible ML Experiment Tracking System for Python Coders with DVC and Streamlit",
   "videos": [
     {
       "length": 1967,

--- a/pycon-us-2022/videos/talk-antoine-toubhans-flexible-ml-experiment-tracking-system-for-python-coders-with-dvc-and-st.json
+++ b/pycon-us-2022/videos/talk-antoine-toubhans-flexible-ml-experiment-tracking-system-for-python-coders-with-dvc-and-st.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "There are so many tools to do data science today that it can be difficult to navigate. Many of them are AI platforms that \u201cdo everything by clicking on a UI\u201d and do not leverage pre-existing tools e.g., GIT for versioning, or good old python IDE instead of Jupyter Notebooks. On the other hand, ML engineering is not classical software engineering:\n\nin addition to the code, the data should also be versioned;\nin its essence, ML engineering is an exploratory work: one can not know if the model is going to work before testing it;\nthere is no clear way to guarantee the quality of the trained model: the data-scientist has to play with it to make it \u201ctalk\u201d.\nIn this talk, we will build a fully customizable and complete system in python to track Machine Learning experiments. For the purpose of this talk, we will train a neural network (Tensorflow) to classify images between cat and dog, though, the main focus is on the tooling and not the ML algorithm. We will use:\n\nDVC (Data Version Control) to 1) version the data alongside the code with GIT 2) build training pipelines to orchestrate the python scripts 3) version experiments.\nStreamlit to build data exploration apps to play with the trained models.\nBoth DVC and Streamlit are open-source libraries with python APIs.\nIn the second part of the talk, we will focus on various ways of combining DVC and Streamlit. For instance, we will see how to build a Streamlit app that allows selecting any trained model tracked with DVC (provided its GIT commit), loading it, and testing it on given input images.\n\nI will provide code samples and live demos throughout the talk.",
+  "duration": 1967,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Antoine Toubhans"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/EGIzJIfAy7g/maxresdefault.jpg",
+  "title": "Talk - Antoine Toubhans: Flexible ML Experiment Tracking System for Python Coders with DVC and St...",
+  "videos": [
+    {
+      "length": 1967,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=EGIzJIfAy7g"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-benjamin-bariteau-how-we-migrated-3-8-million-lines-of-python-2-without-interrupting-deve.json
+++ b/pycon-us-2022/videos/talk-benjamin-bariteau-how-we-migrated-3-8-million-lines-of-python-2-without-interrupting-deve.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Migrating from python 2 to python 3 is not very easy, but it can be exacerbated by needing to port a large codebase modified frequently by many different developers. Our codebase was nearly 4 million lines of code modified dozens of times a day by hundreds of total developers. It is also business critical, containing a large portion of our most important code and data. We used several tools, techniques, and patterns to achieve the migration without disrupting day-to-day development and keeping regressions a minimum. In this talk, we\u2019ll detail our migration steps, our usage of pre-commit hooks to reduce regressions to fixes, our usage of a reverse proxy to allow granular, low risk rollout for a webapp, and our migration of pickle to rollforward safe json for caching.",
+  "duration": 1610,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Benjamin Bariteau"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/d6QAPcOX5OM/hqdefault.jpg",
+  "title": "Talk - Benjamin Bariteau: How We Migrated 3.8 Million Lines of Python 2 Without Interrupting Deve...",
+  "videos": [
+    {
+      "length": 1610,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=d6QAPcOX5OM"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-benjamin-bariteau-how-we-migrated-3-8-million-lines-of-python-2-without-interrupting-deve.json
+++ b/pycon-us-2022/videos/talk-benjamin-bariteau-how-we-migrated-3-8-million-lines-of-python-2-without-interrupting-deve.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/d6QAPcOX5OM/hqdefault.jpg",
-  "title": "Talk - Benjamin Bariteau: How We Migrated 3.8 Million Lines of Python 2 Without Interrupting Deve...",
+  "title": "How We Migrated 3.8 Million Lines of Python 2 Without Interrupting Development",
   "videos": [
     {
       "length": 1610,

--- a/pycon-us-2022/videos/talk-benjamin-zags-zagorsky-handling-timezones-in-python.json
+++ b/pycon-us-2022/videos/talk-benjamin-zags-zagorsky-handling-timezones-in-python.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Does your code use datetimes? There's a chance it has bugs that show up every night after 7pm!\n\nTimezones and daylight savings time are problems that plague most systems. Even if your system is designed for use in a singe timezone, you still need to be aware of timezones, both figuratively and literally to avoid bugs (Python datetimes that are correctly instantiated are referred to as \"timezone aware\").\n\nThis talk will cover: * Common mistakes with dates and datetimes in Python * How to use timezone aware datetimes in Python * Recipes for common datetime use cases * Recipes for Django",
+  "duration": 1572,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/90/2022-05-05T20%3A14%3A33.164888/Timezones_in_Python.pdf"
+    }
+  ],
+  "speakers": [
+    "Benjamin \"Zags\" Zagorsky"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/XZlPXLsSU2U/hqdefault.jpg",
+  "title": "Talk - Benjamin \"Zags\" Zagorsky: Handling Timezones in Python",
+  "videos": [
+    {
+      "length": 1572,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=XZlPXLsSU2U"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-benjamin-zags-zagorsky-handling-timezones-in-python.json
+++ b/pycon-us-2022/videos/talk-benjamin-zags-zagorsky-handling-timezones-in-python.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/XZlPXLsSU2U/hqdefault.jpg",
-  "title": "Talk - Benjamin \"Zags\" Zagorsky: Handling Timezones in Python",
+  "title": "Handling Timezones in Python",
   "videos": [
     {
       "length": 1572,

--- a/pycon-us-2022/videos/talk-bernat-gabor-how-we-standardized-editable-installs-pep-660-vs-pep-662.json
+++ b/pycon-us-2022/videos/talk-bernat-gabor-how-we-standardized-editable-installs-pep-660-vs-pep-662.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "A Python Enhancement Proposal (PEP) is the method through which the Python community debates and adopts new features to the language. The same mechanism is used to standardize interfaces and methods used by the Python Packaging Ecosystem. The main difference is that while language PEPs are written mostly by core developers, packaging PEPs are written by members of the Python Packaging Authority (PyPA). How we build Python packages was standardized in 2016 through PEP-517 and PEP-518. Editable installs, while widely used and well known through the -e flag in pip, proved to be controversial, so it got left out of those proposals. It has taken another five years to reach a consensus, and I'm happy to say that -- through PEP-660 -- we now have a way for all build back-ends to support editable installs. Join me in this talk, where I'll tell a tale explaining how having competing PEPs and exhausting discussions -- while tiresome -- led to a better solution. Plus, you'll also understand the different options we considered and the solution we developed in the end.",
+  "duration": 1754,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Bern\u00e1t G\u00e1bor"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/Z_-PuPwN6ZI/hqdefault.jpg",
+  "title": "Talk - Bern\u00e1t G\u00e1bor: How we standardized editable installs - PEP 660 vs  PEP 662",
+  "videos": [
+    {
+      "length": 1754,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=Z_-PuPwN6ZI"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-bernat-gabor-how-we-standardized-editable-installs-pep-660-vs-pep-662.json
+++ b/pycon-us-2022/videos/talk-bernat-gabor-how-we-standardized-editable-installs-pep-660-vs-pep-662.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/Z_-PuPwN6ZI/hqdefault.jpg",
-  "title": "Talk - Bern\u00e1t G\u00e1bor: How we standardized editable installs - PEP 660 vs  PEP 662",
+  "title": "How we standardized editable installs - PEP-660 vs. PEP-662",
   "videos": [
     {
       "length": 1754,

--- a/pycon-us-2022/videos/talk-bianca-rosa-observability-driven-development.json
+++ b/pycon-us-2022/videos/talk-bianca-rosa-observability-driven-development.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "You're all happy developing your application but when it comes the time to send it to production and have the first customers testing, you might realize that whenever a bug is found it is just too hard to understand what is going on in a production environment - you often don't have access to the user data, the user account and struggles to reproduce the error and support your customer properly.\n\nThe story is too familiar and probably happened to a lot of of us.\n\nIn this talk, we will walk through techniques and things to consider when writing an application that is going to be supported in a production environment with an eye for observability by having searchable, consistent, and rich log messages.\n\nAt first, the problem will be presented to the audience with a use-case scenario where a developer has no way of knowing what happened with a particular customer in a production environment if an API request fails.\nOpening the code for this request, we will add together the log messages that would've made it possible for the development to debug this problem properly - and then, talk through strategies to keep in mind during the early development of the code.\nWe will also walk through log levels and how to use them properly, making sure the log messages are clean and understandable, how to take take advantage of log's extra fields to have metadata about the messages that we are writing, and the best way to make log messages easily searchable.",
+  "duration": 1858,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Bianca Rosa"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/lxyrmsxY2KA/hqdefault.jpg",
+  "title": "Talk - Bianca Rosa: Observability driven development",
+  "videos": [
+    {
+      "length": 1858,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=lxyrmsxY2KA"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-bianca-rosa-observability-driven-development.json
+++ b/pycon-us-2022/videos/talk-bianca-rosa-observability-driven-development.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/lxyrmsxY2KA/hqdefault.jpg",
-  "title": "Talk - Bianca Rosa: Observability driven development",
+  "title": "Observability driven development",
   "videos": [
     {
       "length": 1858,

--- a/pycon-us-2022/videos/talk-brandt-bucher-a-perfect-match-the-history-design-implementation-and-future-of-python-s.json
+++ b/pycon-us-2022/videos/talk-brandt-bucher-a-perfect-match-the-history-design-implementation-and-future-of-python-s.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/XpxTrDDcpPE/maxresdefault.jpg",
-  "title": "Talk - Brandt Bucher: A Perfect Match The history, design, implementation, and future of Python's...",
+  "title": "A Perfect Match: The history, design, implementation, and future of Python's structural pattern matching",
   "videos": [
     {
       "length": 1450,

--- a/pycon-us-2022/videos/talk-brandt-bucher-a-perfect-match-the-history-design-implementation-and-future-of-python-s.json
+++ b/pycon-us-2022/videos/talk-brandt-bucher-a-perfect-match-the-history-design-implementation-and-future-of-python-s.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Python 3.10 was released on October 4th, bringing with it a major new feature: \"structural pattern matching\". As one of the designers of the feature and its principal implementer, my goal is to introduce you to Python's powerful, dynamic, object-oriented approach to this long-established functional programming construct, and to explore ways that you might use structural pattern matching in your own code. Along the way, we\u2019ll also dive into the history of the match statement, the design process behind it, how it actually works, and what we're already doing to improve it in Python 3.11 and beyond.",
+  "duration": 1450,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/116/2022-04-29T05%3A05%3A28.862819/PyCon_US_2022_Outline.pdf"
+    }
+  ],
+  "speakers": [
+    "Brandt Bucher"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/XpxTrDDcpPE/maxresdefault.jpg",
+  "title": "Talk - Brandt Bucher: A Perfect Match The history, design, implementation, and future of Python's...",
+  "videos": [
+    {
+      "length": 1450,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=XpxTrDDcpPE"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-brendan-collins-who-said-wrangling-geospatial-data-at-scale-was-easy.json
+++ b/pycon-us-2022/videos/talk-brendan-collins-who-said-wrangling-geospatial-data-at-scale-was-easy.json
@@ -27,7 +27,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/wYtoePM83HE/maxresdefault.jpg",
-  "title": "Talk - Brendan Collins: Who Said Wrangling Geospatial Data at Scale was Easy?",
+  "title": "Who Said Wrangling Geospatial Data at Scale was Easy?",
   "videos": [
     {
       "length": 1535,

--- a/pycon-us-2022/videos/talk-brendan-collins-who-said-wrangling-geospatial-data-at-scale-was-easy.json
+++ b/pycon-us-2022/videos/talk-brendan-collins-who-said-wrangling-geospatial-data-at-scale-was-easy.json
@@ -1,0 +1,38 @@
+{
+  "copyright_text": null,
+  "description": "If you have ever worked with Census Data, you may be recalling nightmares of hours spent staring at data and finding it impossible to download, store, or convert to a sensible format to begin your analysis. And Census data is not even unstructured data!\n\nGeospatial Data comes in various formats - GeoJSON, Parquet, Shapefiles, GeoTIFF, etc. But what are the most efficient ways to convert the data into formats that are easy to understand, work with, transfer, and ultimately analyze? Then throw in petabytes worth of data and you hit the challenge of wrangling geospatial data at scale.\n\nThis talk will walk through some of the best ways to handle geospatial data at scale, with a focus on:\n\n- The xarray-spatial library (https://xarray-spatial.org/) for raster-based spatial analysis.\n- The RTXpy (https://github.com/makepath/rtxpy) for GPU-powered spatial analysis.\n- Microsoft Planetary Computer (https://planetarycomputer.microsoft.com/) examples of geospatial data processing.",
+  "duration": 1535,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "https://github.com/makepath/rtxpy",
+      "url": "https://github.com/makepath/rtxpy"
+    },
+    {
+      "label": "https://xarray-spatial.org/",
+      "url": "https://xarray-spatial.org/"
+    },
+    {
+      "label": "https://planetarycomputer.microsoft.com/",
+      "url": "https://planetarycomputer.microsoft.com/"
+    }
+  ],
+  "speakers": [
+    "Brendan Collins"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/wYtoePM83HE/maxresdefault.jpg",
+  "title": "Talk - Brendan Collins: Who Said Wrangling Geospatial Data at Scale was Easy?",
+  "videos": [
+    {
+      "length": 1535,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=wYtoePM83HE"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-bruce-eckel-making-data-classes-work-for-you.json
+++ b/pycon-us-2022/videos/talk-bruce-eckel-making-data-classes-work-for-you.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "This will be a example-driven presentation. The first set of examples looks at\nan int which should be restricted to a value from one through ten.\n\nFirst I'll look at the problems in the traditional approach, passing an int\nto a function and checking to ensure it is within range.\n\nNext I'll encapsulate the int in a (regular) class OneToTen, which allows\nthe movement of the test into the constructor. Although this guarantees that\nobjects will be created correctly, such objects are mutable so they can be\nmodified to be invalid after creation.\n\nThe solution is to use @dataclass together with the frozen=True option, and\nadd a __post_init__ function to check the validity of the object once it's\nbeen initialized. Because such an object is invariant, it cannot be later\nmodified into an invalid state. This ensures that the new type can only ever\nexist as a legitimate value.\n\nNext I'll use this technique to create a Person type that is composed of\nFullName, BirthDate and EmailAddress fields, each of which validates\nitself. Finally, I'll compose BirthDate using Day, Month and Year\nfields.",
+  "duration": 1717,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Bruce Eckel"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/w77Kjs5dEko/maxresdefault.jpg",
+  "title": "Talk - Bruce Eckel: Making Data Classes Work for You",
+  "videos": [
+    {
+      "length": 1717,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=w77Kjs5dEko"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-bruce-eckel-making-data-classes-work-for-you.json
+++ b/pycon-us-2022/videos/talk-bruce-eckel-making-data-classes-work-for-you.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/w77Kjs5dEko/maxresdefault.jpg",
-  "title": "Talk - Bruce Eckel: Making Data Classes Work for You",
+  "title": "Making Data Classes Work for You",
   "videos": [
     {
       "length": 1717,

--- a/pycon-us-2022/videos/talk-calvin-hendryx-parker-bootstrapping-your-local-python-environment.json
+++ b/pycon-us-2022/videos/talk-calvin-hendryx-parker-bootstrapping-your-local-python-environment.json
@@ -1,0 +1,102 @@
+{
+  "copyright_text": "CC BY",
+  "description": "There are simple, yet crucial, reminders that can differentiate an expert developer from a hobbyist. In this talk and live demo, developers will learn:\n\n- the importance of abiding by the Zen of Python;\n- where (and how) to install Python on your machine;\n- three rules to follow when installing Python;\n- proper version management with pyenv;\n- which Python add-ons (e.g.: virtualenv, pipx, piptools, Docker) can be used to make environments both repeatable and simple.\n\nResources and Links\n\n- ActiveState: https://www.activestate.com/products/python/\n- asdf: https://github.com/danhper/asdf-python\n- Anaconda: https://www.anaconda.com/products/individual\n- Brew: https://brew.sh/\n- Chocolatey: https://chocolatey.org/\n- Docker\u2019s Python integration: https://hub.docker.com/_/python/\n- PDM: https://pypi.org/project/pdm/\n- pyenv setup: https://github.com/pyenv/pyenv#installation\n- pyenv setup for Windows: https://pyenv-win.github.io/pyenv-win/\n- pipenv versions: https://pipenv.pypa.io/en/latest/\n- piptools: https://github.com/jazzband/pip-tools/#readme\n- pipx setup: https://pypi.org/project/pipx/\n- pipx: https://pypa.github.io/pipx/\n- poetry: https://python-poetry.org/\n- pyproject.toml: https://www.python.org/dev/peps/pep-0621/\n- Python.org: https://python.org/\n- virtualenv: https://virtualenv.pypa.io/en/latest/\n- virtualenvwrapper: https://virtualenvwrapper.readthedocs.io/en/latest/\n- Zen of Python: https://www.python.org/dev/peps/pep-0020/",
+  "duration": 1775,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "https://github.com/pyenv/pyenv#installation",
+      "url": "https://github.com/pyenv/pyenv#installation"
+    },
+    {
+      "label": "https://pypa.github.io/pipx/",
+      "url": "https://pypa.github.io/pipx/"
+    },
+    {
+      "label": "https://virtualenv.pypa.io/en/latest/",
+      "url": "https://virtualenv.pypa.io/en/latest/"
+    },
+    {
+      "label": "https://pypi.org/project/pdm/",
+      "url": "https://pypi.org/project/pdm/"
+    },
+    {
+      "label": "https://github.com/jazzband/pip-tools/#readme",
+      "url": "https://github.com/jazzband/pip-tools/#readme"
+    },
+    {
+      "label": "https://chocolatey.org/",
+      "url": "https://chocolatey.org/"
+    },
+    {
+      "label": "https://www.python.org/dev/peps/pep-0621/",
+      "url": "https://www.python.org/dev/peps/pep-0621/"
+    },
+    {
+      "label": "https://pypi.org/project/pipx/",
+      "url": "https://pypi.org/project/pipx/"
+    },
+    {
+      "label": "https://www.anaconda.com/products/individual",
+      "url": "https://www.anaconda.com/products/individual"
+    },
+    {
+      "label": "https://github.com/danhper/asdf-python",
+      "url": "https://github.com/danhper/asdf-python"
+    },
+    {
+      "label": "https://pipenv.pypa.io/en/latest/",
+      "url": "https://pipenv.pypa.io/en/latest/"
+    },
+    {
+      "label": "https://python-poetry.org/",
+      "url": "https://python-poetry.org/"
+    },
+    {
+      "label": "https://virtualenvwrapper.readthedocs.io/en/latest/",
+      "url": "https://virtualenvwrapper.readthedocs.io/en/latest/"
+    },
+    {
+      "label": "https://brew.sh/",
+      "url": "https://brew.sh/"
+    },
+    {
+      "label": "https://www.activestate.com/products/python/",
+      "url": "https://www.activestate.com/products/python/"
+    },
+    {
+      "label": "https://python.org/",
+      "url": "https://python.org/"
+    },
+    {
+      "label": "https://pyenv-win.github.io/pyenv-win/",
+      "url": "https://pyenv-win.github.io/pyenv-win/"
+    },
+    {
+      "label": "https://hub.docker.com/_/python/",
+      "url": "https://hub.docker.com/_/python/"
+    },
+    {
+      "label": "https://www.python.org/dev/peps/pep-0020/",
+      "url": "https://www.python.org/dev/peps/pep-0020/"
+    }
+  ],
+  "speakers": [
+    "Calvin Hendryx-Parker"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/-YEUFGFHWgQ/maxresdefault.jpg",
+  "title": "Talk - Calvin Hendryx-Parker: Bootstrapping Your Local Python Environment",
+  "videos": [
+    {
+      "length": 1775,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=-YEUFGFHWgQ"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-calvin-hendryx-parker-bootstrapping-your-local-python-environment.json
+++ b/pycon-us-2022/videos/talk-calvin-hendryx-parker-bootstrapping-your-local-python-environment.json
@@ -91,7 +91,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/-YEUFGFHWgQ/maxresdefault.jpg",
-  "title": "Talk - Calvin Hendryx-Parker: Bootstrapping Your Local Python Environment",
+  "title": "Bootstrapping Your Local Python Environment",
   "videos": [
     {
       "length": 1775,

--- a/pycon-us-2022/videos/talk-carlos-kidman-testing-machine-learning-models.json
+++ b/pycon-us-2022/videos/talk-carlos-kidman-testing-machine-learning-models.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/UHbBU8gz7Dw/maxresdefault.jpg",
-  "title": "Talk - Carlos Kidman: Testing Machine Learning Models",
+  "title": "Testing Machine Learning Models",
   "videos": [
     {
       "length": 1872,

--- a/pycon-us-2022/videos/talk-carlos-kidman-testing-machine-learning-models.json
+++ b/pycon-us-2022/videos/talk-carlos-kidman-testing-machine-learning-models.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "As ML/AI systems are becoming more prevalent, the need for setting quality standards and testing practices has become crucial. Testing these models goes beyond validation metrics like accuracy, precision, and recall.\n\nInstead, quality attributes like model Behaviors, Usability, and Fairness need to be tested and measured using exploratory and automated strategies.\n\nIn this talk, we'll cover some of the risks and biases that can happen throughout the MLOps pipeline, demonstrate a few techniques to test a model's behaviors and fairness, and apply them against some real-world scenarios and state-of-the-art models.\n\nBy the end, you will have new ideas and techniques that you can use to test your own ML/AI systems and approach testing these quality attributes from a user's perspective.",
+  "duration": 1872,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Carlos Kidman"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/UHbBU8gz7Dw/maxresdefault.jpg",
+  "title": "Talk - Carlos Kidman: Testing Machine Learning Models",
+  "videos": [
+    {
+      "length": 1872,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=UHbBU8gz7Dw"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-christopher-ariza-employing-numpy-s-npy-format-for-faster-than-parquet-dataframe.json
+++ b/pycon-us-2022/videos/talk-christopher-ariza-employing-numpy-s-npy-format-for-faster-than-parquet-dataframe.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/HLH5AwF-jx4/hqdefault.jpg",
-  "title": "Talk - Christopher Ariza: Employing NumPy's NPY Format for Faster Than Parquet DataFrame...",
+  "title": "Employing NumPy's NPY Format for Faster-Than-Parquet DataFrame Serialization",
   "videos": [
     {
       "length": 1704,

--- a/pycon-us-2022/videos/talk-christopher-ariza-employing-numpy-s-npy-format-for-faster-than-parquet-dataframe.json
+++ b/pycon-us-2022/videos/talk-christopher-ariza-employing-numpy-s-npy-format-for-faster-than-parquet-dataframe.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Over 14 years ago the first NumPy Enhancement Proposal (NEP) defined the NPY format (a binary encoding of array data and metadata) and the NPZ format (zipped bundles of NPY files). Those same formats, extended in a custom NPZ packaged with JSON metadata, can be used in Python to create a stable DataFrame storage format that can materially out-perform Parquet read / write times in a wide range of contexts. Unlike Parquet, all characteristics of a DataFrame can be encoded and all NumPy dtypes are supported. Implemented in StaticFrame, this format can take advantage of an immutable data model to memory-map full DataFrames from un-zipped directories of NPY. Given wide-spread use of Parquet files in data science workflows, a faster-than-Parquet file format can significantly reduce compute costs.\n\nI will begin this talk by introducing the challenge of serializing DataFrames, illustrating how nearly all stable encoding formats lack full support for all DataFrame characteristics. While the broadly-used Parquet format has been called a \"gold standard\" binary file format, its columnar representation will be shown to have limitations when used for encoding DataFrames.\n\nI will show how the NPY format, combined with JSON metadata, can be used to create a custom NPZ file with significant performance and compatibility advantages compared to Parquet. The details of this encoding scheme will be explained.\n\nI will close the talk by evaluating numerous read / write performance comparisons between Parquet (via Pandas) and NPZ (via StaticFrame), measured with a wide variety of DataFrame shapes and dtype compositions. I will share techniques used in implementing optimized Python routines for reading and writing NPY files, and demonstrate applications for memory-mapping complete DataFrames via the same NPY representation.",
+  "duration": 1704,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/29/2022-04-29T13%3A59%3A23.738312/pycon-ariza.pdf"
+    }
+  ],
+  "speakers": [
+    "Christopher Ariza"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/HLH5AwF-jx4/hqdefault.jpg",
+  "title": "Talk - Christopher Ariza: Employing NumPy's NPY Format for Faster Than Parquet DataFrame...",
+  "videos": [
+    {
+      "length": 1704,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=HLH5AwF-jx4"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-christopher-neugebauer-fast-and-reproducible-tests-packaging-and-deploys-with.json
+++ b/pycon-us-2022/videos/talk-christopher-neugebauer-fast-and-reproducible-tests-packaging-and-deploys-with.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "\u201cWorks on my machine\u201d: The cry of developers who can\u2019t reproduce a bug because their development environment is incompatible with their deployment environment. It\u2019s common because setting up clean environments is slow, tedious, and error-prone.\n\nMeanwhile, debugging errors introduced by incorrect environments is slow, tedious, and error-prone.\n\nEach step in your CI workflow theoretically only has inputs or outputs, but in reality, files can be left along the way by running tests or compiling extensions. These are side-effects, not inputs for subsequent steps in your workflow, let alone deployment, but if included they can affect correctness.\n\nYou can solve this using \u201chermetic environments\u201d: running every step of your workflow inside a fresh environment, so steps run truly independently of one another. You can do this manually with Docker, but it\u2019s difficult: you have to understand which inputs are necessary for a step, which newly generated files are meaningful outputs, and what should be discarded.\n\nPantsbuild uses hermetic builds automatically: it understands the inputs each step needs, what outputs it produces, and stores inputs and outputs inside a content-addressable database so it can rapidly build sandboxed environments for subsequent steps of your workflow.\n\nThe result is a build process where every step is run in isolation, with only the inputs each process truly needs, and only true outputs made available to each subsequent step. Pants\u2019 workflows are fast but verifiably correct \u2014 running against incorrect inputs is not a possible failure case.\n\nIn this talk, we\u2019ll explore how Pantsbuild enables truly hermetic builds. We\u2019ll look at other approaches to sandboxing and how they compare to Pants\u2019 approach, and how you can benefit from adding hermetic builds to your project.\n\nYou\u2019ll walk away being confident that \u201cworks on my machine\u201d means \u201cworks everywhere\u201d.",
+  "duration": 1746,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Christopher Neugebauer"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/0INmW9KaAp4/maxresdefault.jpg",
+  "title": "Talk - Christopher Neugebauer: Fast and reproducible tests, packaging, and deploys with...",
+  "videos": [
+    {
+      "length": 1746,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=0INmW9KaAp4"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-christopher-neugebauer-fast-and-reproducible-tests-packaging-and-deploys-with.json
+++ b/pycon-us-2022/videos/talk-christopher-neugebauer-fast-and-reproducible-tests-packaging-and-deploys-with.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/0INmW9KaAp4/maxresdefault.jpg",
-  "title": "Talk - Christopher Neugebauer: Fast and reproducible tests, packaging, and deploys with...",
+  "title": "Fast and reproducible tests, packaging, and deploys with Pantsbuild\u2019s hermetic environments",
   "videos": [
     {
       "length": 1746,

--- a/pycon-us-2022/videos/talk-cillian-kieran-open-source-python-based-tools-for-data-privacy.json
+++ b/pycon-us-2022/videos/talk-cillian-kieran-open-source-python-based-tools-for-data-privacy.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/tuhJiz9_V6o/hqdefault.jpg",
-  "title": "Talk - Cillian Kieran: Open Source, Python Based Tools For Data Privacy",
+  "title": "Open Source, Python Based Tools For Data Privacy",
   "videos": [
     {
       "length": 1750,

--- a/pycon-us-2022/videos/talk-cillian-kieran-open-source-python-based-tools-for-data-privacy.json
+++ b/pycon-us-2022/videos/talk-cillian-kieran-open-source-python-based-tools-for-data-privacy.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "In this talk, I make the case that the developer community has an opportunity to profoundly improve data privacy by shifting privacy upstream into the SDLC, where it belongs. I will share resources and lessons learned from my team's development of open-source, Python-based devtools for data privacy. Analogous to physical infrastructure, our digital infrastructure needs to be designed with trustworthiness at the forefront. As developers, we have often been left out of important design decisions about how technical systems actually process personal data. Typically, privacy risk is addressed reactively, and developers have to manually fulfill users' privacy requests across disparate data infrastructure. This reactive, burdensome approach to privacy pits trustworthiness against innovation. To build trustworthy systems at scale, we need devtools for proactive privacy, and the tools must fit within existing developer workflows.\n\nI will walk through the existing points of friction for developers today, the power of privacy embedded into the SDLC, and the tight bond between open-source and privacy. My team and I have learned that we can improve privacy at scale when the tools for privacy fit into developers' existing workflows and the infrastructure they use every day, including Snowflake warehouses, mongoDB databases, Redis session stores, and more. I will demonstrate what proactive privacy can look like for developers and data engineers: automatic flags for privacy risk in the CI pipeline, and streamlined privacy request fulfillment by traversing distributed data systems for custom data operations\u2014such as deleting personal data while upholding referential integrity across databases.\n\nOpen-source and privacy go hand-in-hand in offering developers and end-users digital infrastructure that they can trust. To tackle a problem as complex as modern privacy, the solution requires all of us to build shared, transparent, and community-informed privacy standards for technology worldwide.",
+  "duration": 1750,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/59/2022-05-01T18%3A53%3A23.697439/Fides-PyCon2022.pdf"
+    }
+  ],
+  "speakers": [
+    "Cillian Kieran"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/tuhJiz9_V6o/hqdefault.jpg",
+  "title": "Talk - Cillian Kieran: Open Source, Python Based Tools For Data Privacy",
+  "videos": [
+    {
+      "length": 1750,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=tuhJiz9_V6o"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-daniel-pope-why-i-reimplemented-trio-in-a-game-engine.json
+++ b/pycon-us-2022/videos/talk-daniel-pope-why-i-reimplemented-trio-in-a-game-engine.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/mxmnl3WJ4bc/hqdefault.jpg",
-  "title": "Talk - Daniel Pope: Why I reimplemented Trio in a game engine",
+  "title": "Why I reimplemented Trio in a game engine",
   "videos": [
     {
       "length": 1534,

--- a/pycon-us-2022/videos/talk-daniel-pope-why-i-reimplemented-trio-in-a-game-engine.json
+++ b/pycon-us-2022/videos/talk-daniel-pope-why-i-reimplemented-trio-in-a-game-engine.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Trio is an asynchronous I/O framework. Unlike other async frameworks in Python, Trio offers structured concurrency: the structure of a program's concurrency tasks are reflected in its code.\n\nThe advantage of structured concurrency is that concurrent programs become easier to reason about, particularly if operations are cancelled.\n\nI reimplemented Trio-like structured concurrency in a game engine, Wasabi2D, and wrote some games with it. I found it to be an excellent fit that simplifies many game logic tasks.\n\nIn this talk I'll talk about concurrency in video games, present structured concurrency with examples found in game logic, and draw parallels between I/O based concurrency tasks and those found in video games.\n\nThe examples will also serve as a tutorial for writing games in Wasabi2D.\n\nFinally I will explore the differences between Wasabi2D and Trio's implementation of the structured concurrency concepts. By comparing the solutions we will see which elements of Trio are foundational to structured concurrency and which are specific choices for Trio's problem space.",
+  "duration": 1534,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/45/2022-04-27T13%3A04%3A31.199690/Why_I_reimplemented_Trio_in_a_game_engine.pdf"
+    }
+  ],
+  "speakers": [
+    "Daniel Pope"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/mxmnl3WJ4bc/hqdefault.jpg",
+  "title": "Talk - Daniel Pope: Why I reimplemented Trio in a game engine",
+  "videos": [
+    {
+      "length": 1534,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=mxmnl3WJ4bc"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-deepak-k-gupta-speed-up-data-access-with-pyarrow-apache-arrow-data-is-the-new-api.json
+++ b/pycon-us-2022/videos/talk-deepak-k-gupta-speed-up-data-access-with-pyarrow-apache-arrow-data-is-the-new-api.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/akfsWPsvmrM/maxresdefault.jpg",
-  "title": "Talk - Deepak K Gupta:  Speed Up Data Access with PyArrow Apache Arrow   Data is the new API",
+  "title": "Speed Up Data Access with PyArrow (Apache Arrow) - Data is the new API",
   "videos": [
     {
       "length": 1525,

--- a/pycon-us-2022/videos/talk-deepak-k-gupta-speed-up-data-access-with-pyarrow-apache-arrow-data-is-the-new-api.json
+++ b/pycon-us-2022/videos/talk-deepak-k-gupta-speed-up-data-access-with-pyarrow-apache-arrow-data-is-the-new-api.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Till now we\u2019re used to accessing data over API\u2019s and the API\u2019s used to make sure that we get the data in the desired format which unfortunately requires data to go through serialization / deserialization cycle before being returned by the API\n\nWhat if we can change or arrange the data in such a way where it neither needs an API nor any serialisation / deserialization to access and understand the data that too using multiple programming languages\n\nIf it sounds interesting then welcome to the world of Apache Arrow which defines a language independent columnar memory format which supports zero-copy reads for lightning-fast data access without serialization overhead.\n\nThe python library of the same is called PyArrow and can be integrated with python specific libraries like pandas and numpy and can propagate the benefits to the same.\n\nWelcome to this talk where you\u2019ll learn about the architecture, use cases and reasons for using Apache Arrow using PyArrow. I\u2019ll share how to as well as some of the interesting statistics of the difference it makes in our day to day access & analytics.\n\nI\u2019ll also talk about Apache Flight, which is a high performance wire protocol focused on bulk transfer for analytics.\n\nThis Session NOT a tutorial about PyArrow but a set of interesting improvements, facts and statistics which can help you to decide whether it makes sense to explore for the work you\u2019re doing.",
+  "duration": 1525,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Deepak K Gupta"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/akfsWPsvmrM/maxresdefault.jpg",
+  "title": "Talk - Deepak K Gupta:  Speed Up Data Access with PyArrow Apache Arrow   Data is the new API",
+  "videos": [
+    {
+      "length": 1525,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=akfsWPsvmrM"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-dustin-ingram-securing-the-open-source-software-supply-chain.json
+++ b/pycon-us-2022/videos/talk-dustin-ingram-securing-the-open-source-software-supply-chain.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/i1QqhGsbX6Y/hqdefault.jpg",
-  "title": "Talk - Dustin Ingram: Securing the Open Source Software Supply Chain",
+  "title": "Securing the Open Source Software Supply Chain",
   "videos": [
     {
       "length": 1783,

--- a/pycon-us-2022/videos/talk-dustin-ingram-securing-the-open-source-software-supply-chain.json
+++ b/pycon-us-2022/videos/talk-dustin-ingram-securing-the-open-source-software-supply-chain.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Supply Chain Security: so hot right now. With the recently increased focus on securing software systems, there has been a incredible explosion of tools, methodologies, standards, best practices, and more. Given the sheer quantity, it's hard to keep track and stay informed: how can you know what's right for you?\n\nThe same attributes that make open source software desirable to use also make it challenging to secure. When anyone can publish an open-source library, how can you decide what's safe to use? If anyone can contribute, how can you trust the maintainers? If source code and development is in public, how can we identify and respond to vulnerabilities when attackers will know about them as soon as we do?\n\nIn this talk, we'll explore new tools and best practices that you can use today as open-source software user to improve the security of your software supply chain and trust in the ecosystem. We'll show how each of these serves a different purpose, and protects you from a unique way in which your software supply chain could be vulnerable. Finally, we'll discuss upcoming and potential improvements to the entire open-source ecosystem.",
+  "duration": 1783,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Dustin Ingram"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/i1QqhGsbX6Y/hqdefault.jpg",
+  "title": "Talk - Dustin Ingram: Securing the Open Source Software Supply Chain",
+  "videos": [
+    {
+      "length": 1783,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=i1QqhGsbX6Y"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-francesco-murdaca-maya-costantini-how-to-make-your-python-jupyter-notebook-standalone-an.json
+++ b/pycon-us-2022/videos/talk-francesco-murdaca-maya-costantini-how-to-make-your-python-jupyter-notebook-standalone-an.json
@@ -1,0 +1,27 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Even though many developers (including data scientists) focus on their core problems when working on their experiments, one basic aspect can make these projects not reusable. We are not considering anything machine learning-related yet.\n\nOne of the first steps during the development of a project is the selection of libraries or dependencies. When someone runs pip install package-name, they might not be aware that along with the library that is going to be installed, so-called direct dependency, many other dependencies will be installed on your machine, so-called transitive dependencies. Any change in one of those dependencies can break your experiment. It\u2019s fundamental to have a way to state all the dependencies used, including the operating system, python interpreter, and hardware used to run a certain experiment.\n\nIn this session, the speakers will present an open source JupyterLab extension for Python dependency management developed by the Thoth team. They will learn what resolution engine can be used (e.g. Pipenv, Thoth), the difference between these resolution engines. Moreover they will learn what to do in different scenarios emulating typical Jupyter notebook experiences to learn how to use the new extension.\n\nBy the end of this session, attendees will learn the importance of reproducibility, how to use the Thoth Jupyterlab extension for Python projects and the benefits of a cloud resolution engine with respect to other existing ones. They will be able to run a tutorial using only a GitHub account and a browser as it will be run in a completely open cloud environment.",
+  "duration": 1540,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Francesco Murdaca",
+    "Maya Costantini"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/xJddVw_ALgY/hqdefault.jpg",
+  "title": "Talk. - Francesco Murdaca/Maya Costantini: How to Make Your Python Jupyter Notebook Standalone an...",
+  "videos": [
+    {
+      "length": 1540,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=xJddVw_ALgY"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-francesco-murdaca-maya-costantini-how-to-make-your-python-jupyter-notebook-standalone-an.json
+++ b/pycon-us-2022/videos/talk-francesco-murdaca-maya-costantini-how-to-make-your-python-jupyter-notebook-standalone-an.json
@@ -16,7 +16,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/xJddVw_ALgY/hqdefault.jpg",
-  "title": "Talk. - Francesco Murdaca/Maya Costantini: How to Make Your Python Jupyter Notebook Standalone an...",
+  "title": "How to Make Your Python Jupyter Notebook Standalone and Reproducible to allow others to replicate your experiments",
   "videos": [
     {
       "length": 1540,

--- a/pycon-us-2022/videos/talk-graham-bleaney-pradeep-kumar-srinivasan-securing-code-with-the-python-type-system.json
+++ b/pycon-us-2022/videos/talk-graham-bleaney-pradeep-kumar-srinivasan-securing-code-with-the-python-type-system.json
@@ -20,7 +20,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/nRt_xk2MGYU/maxresdefault.jpg",
-  "title": "Talk - Graham Bleaney/Pradeep Kumar Srinivasan: Securing Code with the Python Type System",
+  "title": "Securing Code with the Python Type System",
   "videos": [
     {
       "length": 1705,

--- a/pycon-us-2022/videos/talk-graham-bleaney-pradeep-kumar-srinivasan-securing-code-with-the-python-type-system.json
+++ b/pycon-us-2022/videos/talk-graham-bleaney-pradeep-kumar-srinivasan-securing-code-with-the-python-type-system.json
@@ -1,0 +1,31 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Preventing security vulnerabilities often brings to mind heavyweight security tools. But what if it doesn\u2019t have to be that way? What if you could use the concepts already built into Python to make your code incrementally more secure?\n\nIn this talk, we'll see how Python types allow you to improve your project's security incrementally. First, we\u2019ll show how simple type annotations by themselves can prevent security-impacting logic errors. Second, we'll see how you can prevent injection vulnerabilities such as SQL injection using a special type in your APIs (PEP 675). Next, we demonstrate how to leverage runtime type validation to securely deal with user-controlled data (such as HTTP requests). Finally, we show how types naturally enable powerful typing-based tools like Pysa and CodeQL to perform static taint flow analysis and catch complex vulnerabilities that span multiple functions. No security tool is a panacea, however, so we\u2019ll also show you where typing and the tools that rely on it can fail.",
+  "duration": 1705,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/18/2022-04-28T19%3A35%3A09.209346/PyCon_2022_-_Typing_for_Security.pdf"
+    }
+  ],
+  "speakers": [
+    "Graham Bleaney",
+    "Pradeep Kumar Srinivasan"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/nRt_xk2MGYU/maxresdefault.jpg",
+  "title": "Talk - Graham Bleaney/Pradeep Kumar Srinivasan: Securing Code with the Python Type System",
+  "videos": [
+    {
+      "length": 1705,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=nRt_xk2MGYU"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-greg-compestine-how-to-succeed-with-python-across-the-enterprise.json
+++ b/pycon-us-2022/videos/talk-greg-compestine-how-to-succeed-with-python-across-the-enterprise.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/1zRv5vAQCKk/hqdefault.jpg",
-  "title": "Talk - Greg Compestine: How to Succeed with Python Across the Enterprise",
+  "title": "How to Succeed with Python Across the Enterprise",
   "videos": [
     {
       "length": 1536,

--- a/pycon-us-2022/videos/talk-greg-compestine-how-to-succeed-with-python-across-the-enterprise.json
+++ b/pycon-us-2022/videos/talk-greg-compestine-how-to-succeed-with-python-across-the-enterprise.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "As a large, well-established company, Bloomberg focused on C++ as its primary language several decades ago. Python began as a scripting language for writing small utilities. An intern project several years ago showed that it was possible to integrate some C++ libraries with Python, making it possible to build domain-specific applications. An engineer with an affinity for Python got approval to form a small team to provide better support for the language. Engineers also formed small committees (or Guilds) to help promote Python across the organization by advocating for users, organizing meetups, actively monitoring messaging channels to help those with questions and problems, and writing lots and lots of documentation.\n\nToday, Python is used by more than 3,000 of the company's engineers. We actively support the Python Software Foundation and open source Python projects. Python is used to train new hires on the architectural paradigms used within the company. In less than a decade, we\u2019ve gone from taking our first steps with the language to being one of the leading contributors to its evolution.\n\nSometimes success can \"just happen.\" However, most often changing a cultural dynamic takes a lot of hard work. And it is work that can be very rewarding.",
+  "duration": 1536,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/79/2022-04-28T22%3A02%3A15.039467/How_to_Succeed_with_Python.pdf"
+    }
+  ],
+  "speakers": [
+    "Greg Compestine"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/1zRv5vAQCKk/hqdefault.jpg",
+  "title": "Talk - Greg Compestine: How to Succeed with Python Across the Enterprise",
+  "videos": [
+    {
+      "length": 1536,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=1zRv5vAQCKk"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-henry-fredrick-schreiner-iii-building-a-binary-extension.json
+++ b/pycon-us-2022/videos/talk-henry-fredrick-schreiner-iii-building-a-binary-extension.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Support for binary extensions is an exceptional advantage of Python that is too often avoided for smaller packages with low developer resources. Binary extensions are used to achieve high performance for libraries like PyTorch, MyPy, and many thousands more. Binary extensions also allow access to a wealth of existing compiled libraries. Building your own binary extension is plagued by historically poor documentation, bad common practices, and many misconceptions. But it is actually easy to write extensions today that work seamlessly on all common developer platforms using modern libraries and continuous integration.\n\nWe will take a look at packaging a binary extension from start to finish. This starts with pybind11 for C++ bindings, providing simple, header only builds and avoiding the need for a new language or pre-processor step. We will look at scikit-build for building, providing powerful CMake based builds with library search, multithreaded builds, and more. We will use PyPA's build to produce SDists. And we will use PyPA's cibuildwheel to produce binaries for all common platforms with minimal setup and simple CI code in GitHub Actions (but trivially movable to any other CI system). We will talk about how to automate common tasks, like using GitHub's Dependabot to keep cibuildwheel up-to-date while also ensuring reproducible builds.\n\nAfter this talk, it is our hope that you will no longer shy away from using compiled code in libraries, but will feel comfortable writing extensions to accelerate or advance your libraries functionality.",
+  "duration": 2373,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/57/2022-04-29T06%3A17%3A37.414348/CppCon2022_Building_Python_Extensions_AP1.pdf"
+    }
+  ],
+  "speakers": [
+    "Henry Fredrick Schreiner III"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/gROGDQakzas/maxresdefault.jpg",
+  "title": "Talk - Henry Fredrick Schreiner III: Building a binary extension",
+  "videos": [
+    {
+      "length": 2373,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=gROGDQakzas"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-henry-fredrick-schreiner-iii-building-a-binary-extension.json
+++ b/pycon-us-2022/videos/talk-henry-fredrick-schreiner-iii-building-a-binary-extension.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/gROGDQakzas/maxresdefault.jpg",
-  "title": "Talk - Henry Fredrick Schreiner III: Building a binary extension",
+  "title": "Building a binary extension",
   "videos": [
     {
       "length": 2373,

--- a/pycon-us-2022/videos/talk-jan-hein-buhrman-when-to-refactor-your-code-into-generators-and-how.json
+++ b/pycon-us-2022/videos/talk-jan-hein-buhrman-when-to-refactor-your-code-into-generators-and-how.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/2gPdodp6i3Y/maxresdefault.jpg",
-  "title": "Talk - Jan-Hein B\u00fchrman: When to refactor your code into generators and how",
+  "title": "When to refactor your code into generators and how",
   "videos": [
     {
       "length": 1643,

--- a/pycon-us-2022/videos/talk-jan-hein-buhrman-when-to-refactor-your-code-into-generators-and-how.json
+++ b/pycon-us-2022/videos/talk-jan-hein-buhrman-when-to-refactor-your-code-into-generators-and-how.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Have you ever found yourself coding variations of a loop construct where fragments of the loop code were exactly the same between the variations? Or, in an attempt to factor out these common parts, you ended up with a loop construct containing a lot of conditional code for varying start, stop, or selection criteria?\n\nYou might have felt that the end result just didn't look right. Because of the duplicated parts in your code, you noticed that the code didn't conform to the DRY (Don't Repeat Yourself) principle. Or, after an attempt to combine the variations into a single loop, with consequently a lot of conditional code, your inner voice told you that the resulting code had become too complex and difficult to maintain.\n\nThis talk will show you a way out of this situation. It demonstrates how you can create a generator function that implements only the common parts of your loop construct. Subsequently you will learn how you can combine this generator function with distinct hand-crafted functions or building blocks from the standard library itertools module or the more-itertools package.\n\nAs an example, imagine you'd need to implement some varying functionality based on the Fibonacci sequence. This talk shows you how it would look like before and after you've refactored it into a pipeline of generators.\n\nAfter having seen this pattern, you will recognize more quickly when this kind of refactoring helps you to create more maintainable and more Pythonic code.",
+  "duration": 1643,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/121/2022-04-29T17%3A23%3A39.884992/How_to_Refactor_into_Generator_Functi_eM5I4Ei.pdf"
+    }
+  ],
+  "speakers": [
+    "Jan-Hein B\u00fchrman"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/2gPdodp6i3Y/maxresdefault.jpg",
+  "title": "Talk - Jan-Hein B\u00fchrman: When to refactor your code into generators and how",
+  "videos": [
+    {
+      "length": 1643,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=2gPdodp6i3Y"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-jason-fried-if-an-asyncio-task-fails-in-the-woods-and-nobody-is-around-to-see-it-does-i.json
+++ b/pycon-us-2022/videos/talk-jason-fried-if-an-asyncio-task-fails-in-the-woods-and-nobody-is-around-to-see-it-does-i.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/XW7yv6HuWTE/hqdefault.jpg",
-  "title": "Talk - Jason Fried: If an asyncio Task fails in the woods and nobody is around to see it, does i....",
+  "title": "If an asyncio.Task fails in the woods and nobody is around to see it, does it still page you at 3am",
   "videos": [
     {
       "length": 1665,

--- a/pycon-us-2022/videos/talk-jason-fried-if-an-asyncio-task-fails-in-the-woods-and-nobody-is-around-to-see-it-does-i.json
+++ b/pycon-us-2022/videos/talk-jason-fried-if-an-asyncio-task-fails-in-the-woods-and-nobody-is-around-to-see-it-does-i.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Its 3am you just got called about some asyncio production code that is failing either cryptically or silently. You discover that its using some terrible pattern and say to yourself \"how did this ever work?\". Come find out about some bad asyncio usage patterns and how to combat them in your projects. We will talk about useful patterns for bootstrapping and tear down, and give you the tools you need to improve the code you maintain.",
+  "duration": 1665,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Jason Fried"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/XW7yv6HuWTE/hqdefault.jpg",
+  "title": "Talk - Jason Fried: If an asyncio Task fails in the woods and nobody is around to see it, does i....",
+  "videos": [
+    {
+      "length": 1665,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=XW7yv6HuWTE"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-jeremiah-paige-intro-to-introspection.json
+++ b/pycon-us-2022/videos/talk-jeremiah-paige-intro-to-introspection.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/2XDT37Tbv9c/hqdefault.jpg",
-  "title": "Talk - Jeremiah Paige: Intro to Introspection",
+  "title": "Intro to Introspection",
   "videos": [
     {
       "length": 1378,

--- a/pycon-us-2022/videos/talk-jeremiah-paige-intro-to-introspection.json
+++ b/pycon-us-2022/videos/talk-jeremiah-paige-intro-to-introspection.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Python has immensely powerful capabilities to find information about objects and running code; even code you did not directly create. Through examples I will show you where that information is kept, how to retrieve it, and how to make sense of it.",
+  "duration": 1378,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/5/2022-04-27T04%3A21%3A44.122463/Intro_to_Introspection.pdf"
+    }
+  ],
+  "speakers": [
+    "Jeremiah Paige"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/2XDT37Tbv9c/hqdefault.jpg",
+  "title": "Talk - Jeremiah Paige: Intro to Introspection",
+  "videos": [
+    {
+      "length": 1378,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=2XDT37Tbv9c"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-jes-ford-the-model-review-improving-transparency-reproducibility-knowledge-sharing.json
+++ b/pycon-us-2022/videos/talk-jes-ford-the-model-review-improving-transparency-reproducibility-knowledge-sharing.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/HPW2sw4VfeA/maxresdefault.jpg",
-  "title": "Talk - Jes Ford: The Model Review: improving transparency, reproducibility, & knowledge sharing...",
+  "title": "The Model Review: improving transparency, reproducibility, & knowledge sharing using MLflow",
   "videos": [
     {
       "length": 1622,

--- a/pycon-us-2022/videos/talk-jes-ford-the-model-review-improving-transparency-reproducibility-knowledge-sharing.json
+++ b/pycon-us-2022/videos/talk-jes-ford-the-model-review-improving-transparency-reproducibility-knowledge-sharing.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Code Review is an integral part of software development, but many teams don\u2019t have similar processes in place for the development and deployment of Machine Learning (ML) models. I will motivate the decision to create a Model Review process, starting from the principles of transparency, reproducibility, and knowledge sharing. MLflow is a useful Python package to help simplify and automate much of the tracking necessary to create detailed records of machine learning experiments. Much of this talk will be spent introducing this tool, and demonstrating the core MLflow Tracking functionality. I\u2019ll discuss how my team is currently running a Model Review process for any ML models that we push to production, and how we use MLflow to streamline this work and learn from each other.",
+  "duration": 1622,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/68/2022-04-26T03%3A24%3A02.545732/model_review_slides_jesford.pdf"
+    }
+  ],
+  "speakers": [
+    "Jes Ford"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/HPW2sw4VfeA/maxresdefault.jpg",
+  "title": "Talk - Jes Ford: The Model Review: improving transparency, reproducibility, & knowledge sharing...",
+  "videos": [
+    {
+      "length": 1622,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=HPW2sw4VfeA"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-jessica-temporal-let-s-talk-about-jwt.json
+++ b/pycon-us-2022/videos/talk-jessica-temporal-let-s-talk-about-jwt.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "JSON Web Tokens, or JWTs for short, are all over the web. They can be used to track bits of information about a user in a very compact way and can be used in APIs for authorization purposes. Join me and learn what JWTs are, what problems it solves, how you can use JWTs, and how to be safer when using JWTs on your applications.",
+  "duration": 1366,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/33/2022-04-24T16%3A05%3A50.711928/pycon-jwt.pdf"
+    }
+  ],
+  "speakers": [
+    "Jessica Temporal"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/JyvJYkbzBNc/hqdefault.jpg",
+  "title": "Talk - Jessica Temporal: Let's talk about JWT",
+  "videos": [
+    {
+      "length": 1366,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=JyvJYkbzBNc"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-jessica-temporal-let-s-talk-about-jwt.json
+++ b/pycon-us-2022/videos/talk-jessica-temporal-let-s-talk-about-jwt.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/JyvJYkbzBNc/hqdefault.jpg",
-  "title": "Talk - Jessica Temporal: Let's talk about JWT",
+  "title": "Let's talk about JWT",
   "videos": [
     {
       "length": 1366,

--- a/pycon-us-2022/videos/talk-jigyasa-grover-rishabh-misra-sculpting-data-for-machine-learning-v02.json
+++ b/pycon-us-2022/videos/talk-jigyasa-grover-rishabh-misra-sculpting-data-for-machine-learning-v02.json
@@ -1,0 +1,27 @@
+{
+  "copyright_text": "CC BY",
+  "description": "In the contemporary world of machine learning algorithms - \u201cdata is the new oil\u201d. For the state-of-the-art ML algorithms to work their magic it\u2019s important to lay a strong foundation with access to relevant data. Volumes of crude data are available on the web nowadays, and all we need are the skills to identify and extract meaningful datasets. This talk aims to present the power of the most fundamental aspect of Machine Learning - Dataset Curation, which often does not get its due limelight. It will also walk the audience through the process of constructing good quality datasets as done in formal settings with a simple hands-on Pythonic example. The goal is to institute the importance of data, especially in its worthy format, and the spell it casts on fabricating smart learning algorithms.",
+  "duration": 1690,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Jigyasa Grover",
+    "Rishabh Misra"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/jAU1og-DqJ8/hqdefault.jpg",
+  "title": "Talk: Jigyasa Grover/Rishabh Misra: Sculpting Data for Machine Learning V02",
+  "videos": [
+    {
+      "length": 1690,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=jAU1og-DqJ8"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-jigyasa-grover-rishabh-misra-sculpting-data-for-machine-learning-v02.json
+++ b/pycon-us-2022/videos/talk-jigyasa-grover-rishabh-misra-sculpting-data-for-machine-learning-v02.json
@@ -16,7 +16,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/jAU1og-DqJ8/hqdefault.jpg",
-  "title": "Talk: Jigyasa Grover/Rishabh Misra: Sculpting Data for Machine Learning V02",
+  "title": "Sculpting Data for Machine Learning V02",
   "videos": [
     {
       "length": 1690,

--- a/pycon-us-2022/videos/talk-john-reese-open-source-on-easy-mode.json
+++ b/pycon-us-2022/videos/talk-john-reese-open-source-on-easy-mode.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Open source is the lifeblood of the community, and we all stand on the shoulders of giants. But the responsibility, time commitment, and processes that come with maintaining projects on PyPI can be overwhelming, even for the best of us. With this talk, we'll see how the right tools and automation can cut out the overhead from running open source projects, and let you focus on the fun parts!\n\nWe'll cover a wide range of topics, from packaging, metadata, and dependencies, to code quality, testing, and CI/CD, and finish with documentation, helping new developers, and reviewing contributions from the community. We'll look at high level concepts, modern best practices, and free tools available and how they make it easier than ever for new contributors to get started, while giving you confidence that their changes are safe and ready for production.\n\nRather than just pointing to cookie cutter templates, we'll talk about the \"why\" behind these best practices and how they fit into common developer workflows. We'll also include links to references and popular developer tools, as well as a companion site with slides and a list of everything mentioned in the talk.\n\nDevelopers of all experience levels are welcome. Whether you're new to packaging and need guidance for your first release, or a seasoned package maintainer looking to simplify your workflow, this talk is for you!",
+  "duration": 1566,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/104/2022-04-28T21%3A41%3A15.777027/open-source-easy-mode.pdf"
+    }
+  ],
+  "speakers": [
+    "John Reese"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/lSqyKoPYtr0/maxresdefault.jpg",
+  "title": "Talk - John Reese: Open Source on Easy Mode",
+  "videos": [
+    {
+      "length": 1566,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=lSqyKoPYtr0"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-john-reese-open-source-on-easy-mode.json
+++ b/pycon-us-2022/videos/talk-john-reese-open-source-on-easy-mode.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/lSqyKoPYtr0/maxresdefault.jpg",
-  "title": "Talk - John Reese: Open Source on Easy Mode",
+  "title": "Open Source on Easy Mode",
   "videos": [
     {
       "length": 1566,

--- a/pycon-us-2022/videos/talk-joseph-lucas-serialization-more-than-pickling.json
+++ b/pycon-us-2022/videos/talk-joseph-lucas-serialization-more-than-pickling.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/ygrjAGDU1J8/hqdefault.jpg",
-  "title": "Talk - Joseph Lucas: Serialization  More than pickling",
+  "title": "Serialization: More than pickling",
   "videos": [
     {
       "length": 1433,

--- a/pycon-us-2022/videos/talk-joseph-lucas-serialization-more-than-pickling.json
+++ b/pycon-us-2022/videos/talk-joseph-lucas-serialization-more-than-pickling.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Have you ever needed to persist an object or instance? You probably researched serialization (converting an object to a byte-stream). The default for python is pickle, but there are other serialization options. In this talk, we'll explore some of those other options as well as their efficiency and security considerations.",
+  "duration": 1433,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Joseph Lucas"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/ygrjAGDU1J8/hqdefault.jpg",
+  "title": "Talk - Joseph Lucas: Serialization  More than pickling",
+  "videos": [
+    {
+      "length": 1433,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=ygrjAGDU1J8"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-josh-weissbock-distributed-web-scraping-in-python.json
+++ b/pycon-us-2022/videos/talk-josh-weissbock-distributed-web-scraping-in-python.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/eVdHmaE3tSM/maxresdefault.jpg",
-  "title": "Talk - Josh Weissbock: Distributed Web Scraping in Python",
+  "title": "Distributed Web Scraping in Python",
   "videos": [
     {
       "length": 1417,

--- a/pycon-us-2022/videos/talk-josh-weissbock-distributed-web-scraping-in-python.json
+++ b/pycon-us-2022/videos/talk-josh-weissbock-distributed-web-scraping-in-python.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Web scraping is easy to do in Python, but it quickly becomes tedious when routinely running large batch scraping jobs. This talk looks at how to build a distributed web scraper to reduce batch scraping job times and improve durability of your code as well as lessons learned & stories along the way.",
+  "duration": 1417,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/48/2022-04-29T04%3A28%3A21.308613/PyCon_2022_-_Distributed_Web_Scraping.pdf"
+    }
+  ],
+  "speakers": [
+    "Josh Weissbock"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/eVdHmaE3tSM/maxresdefault.jpg",
+  "title": "Talk - Josh Weissbock: Distributed Web Scraping in Python",
+  "videos": [
+    {
+      "length": 1417,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=eVdHmaE3tSM"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-juan-gonzalez-improving-app-performance-with-snapshots.json
+++ b/pycon-us-2022/videos/talk-juan-gonzalez-improving-app-performance-with-snapshots.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Improving your app's performance is a complicated but essential task to handle growth.\n\nOften, the bottleneck for your system is your database.\n\nWhile there are many strategies on scaling your database infrastructure, there isn't a clear strategy for solving your performance issues by improving your Python code.\n\nCome to this talk to learn how a recently open-sourced library named \"snapshot-queries\" can help you write Python code that helps you scale without spending more!",
+  "duration": 1420,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Juan Gonzalez"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/0cNBVt8UvI8/maxresdefault.jpg",
+  "title": "Talk - Juan Gonzalez: Improving App Performance with Snapshots",
+  "videos": [
+    {
+      "length": 1420,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=0cNBVt8UvI8"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-juan-gonzalez-improving-app-performance-with-snapshots.json
+++ b/pycon-us-2022/videos/talk-juan-gonzalez-improving-app-performance-with-snapshots.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/0cNBVt8UvI8/maxresdefault.jpg",
-  "title": "Talk - Juan Gonzalez: Improving App Performance with Snapshots",
+  "title": "Improving App Performance with Snapshots",
   "videos": [
     {
       "length": 1420,

--- a/pycon-us-2022/videos/talk-kelly-schuster-paredes-sean-tibor-learn-python-like-a-12-year-old.json
+++ b/pycon-us-2022/videos/talk-kelly-schuster-paredes-sean-tibor-learn-python-like-a-12-year-old.json
@@ -16,7 +16,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/OAYhKUozqf4/maxresdefault.jpg",
-  "title": "Talk - Kelly Schuster - Paredes/Sean Tibor: Learn Python Like a 12-Year Old",
+  "title": "Learn Python Like a 12-Year Old",
   "videos": [
     {
       "length": 1628,

--- a/pycon-us-2022/videos/talk-kelly-schuster-paredes-sean-tibor-learn-python-like-a-12-year-old.json
+++ b/pycon-us-2022/videos/talk-kelly-schuster-paredes-sean-tibor-learn-python-like-a-12-year-old.json
@@ -1,0 +1,27 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Along the way to adulthood, we often lose that sense of wonder, enjoyment, and playfulness that we had as kids in our favorite school subjects. As adults, we can become better learners ourselves when we examine how kids learn coding with Python. In this session, we\u2019ll talk about making thinking and coding visible, to the brain science behind how we learn new things, to the importance of playfulness in learning. We will share a variety of helpful tips to improve your learning whether you are new to Python or an experienced coder.",
+  "duration": 1628,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Kelly Schuster - Paredes",
+    "Sean Tibor"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/OAYhKUozqf4/maxresdefault.jpg",
+  "title": "Talk - Kelly Schuster - Paredes/Sean Tibor: Learn Python Like a 12-Year Old",
+  "videos": [
+    {
+      "length": 1628,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=OAYhKUozqf4"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-kevin-kho-han-wang-comparing-the-different-ways-to-scale-python-and-pandas-code.json
+++ b/pycon-us-2022/videos/talk-kevin-kho-han-wang-comparing-the-different-ways-to-scale-python-and-pandas-code.json
@@ -1,0 +1,27 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Fugue is an open-source unified interface for Pandas, Spark, and Dask that aims to let data practitioners define their compute workflows in a scale-agnostic manner. By decoupling logic and execution, users can code in a language that they are familiar with (Python, Pandas or SQL), and then choose an execution engine to run it on (Pandas, Spark or Dask). In this talk, we cover the transform() function, which lets a user execute a single function in a distributed setting. This simple interface can be incrementally adopted and allows data practitioners to be productive with distributed computing very quickly.",
+  "duration": 1859,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Kevin Kho",
+    "Han Wang"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/b3ae0m_XTys/maxresdefault.jpg",
+  "title": "Talk - Kevin Kho/Han Wang: Comparing the Different Ways to Scale Python and Pandas Code",
+  "videos": [
+    {
+      "length": 1859,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=b3ae0m_XTys"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-kevin-kho-han-wang-comparing-the-different-ways-to-scale-python-and-pandas-code.json
+++ b/pycon-us-2022/videos/talk-kevin-kho-han-wang-comparing-the-different-ways-to-scale-python-and-pandas-code.json
@@ -16,7 +16,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/b3ae0m_XTys/maxresdefault.jpg",
-  "title": "Talk - Kevin Kho/Han Wang: Comparing the Different Ways to Scale Python and Pandas Code",
+  "title": "Comparing the Different Ways to Scale Python and Pandas Code",
   "videos": [
     {
       "length": 1859,

--- a/pycon-us-2022/videos/talk-kevin-modzelewski-writing-performant-code-for-modern-python-interpreters.json
+++ b/pycon-us-2022/videos/talk-kevin-modzelewski-writing-performant-code-for-modern-python-interpreters.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/z0-4EwIFeJo/maxresdefault.jpg",
-  "title": "Talk - Kevin Modzelewski: Writing performant code for modern Python interpreters",
+  "title": "Writing performant code for modern Python interpreters",
   "videos": [
     {
       "length": 1904,

--- a/pycon-us-2022/videos/talk-kevin-modzelewski-writing-performant-code-for-modern-python-interpreters.json
+++ b/pycon-us-2022/videos/talk-kevin-modzelewski-writing-performant-code-for-modern-python-interpreters.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "This talk will go into the latest efforts to speed up the Python language, and in particular how some things will be sped up much more than others. You may have heard best practices for Python performance before, but there are some new guidelines now, some old ones are no longer as important, and some are no longer true at all. Come to hear how the Python language is being optimized, and what you can do to best take advantage of these optimizations.",
+  "duration": 1904,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Kevin Modzelewski"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/z0-4EwIFeJo/maxresdefault.jpg",
+  "title": "Talk - Kevin Modzelewski: Writing performant code for modern Python interpreters",
+  "videos": [
+    {
+      "length": 1904,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=z0-4EwIFeJo"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-liran-haimovitch-effective-protobuf-everything-you-wanted-to-know-but-never-dared-to-ask.json
+++ b/pycon-us-2022/videos/talk-liran-haimovitch-effective-protobuf-everything-you-wanted-to-know-but-never-dared-to-ask.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "A talk of 40 minutes covering the following topics:\n\n1. Introduction to serialization and its place in software engineering\n2. Static typed vs dynamic typed serialization\n3. Textual vs binary serialization: pros and cons\n4. Popular serialization frameworks\n5. Why Protobuf\n6. Quick intro to Protobuf (just enough to get by)\n7. Protobuf performance challenges and tradeoffs\n8. Async synchronization: pros and cons\n9. Field encoding: under the hood and what we learn\n10. Managing the cost of abstractions\n11. Data deduplication and compression\n12. Field reuse: the whys and hows\n13. gRPC: pros and cons\n14. Protobuf over websocket or HTTP\n15. Thank you",
+  "duration": 1651,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/51/2022-04-29T22%3A04%3A43.392216/Effective_Protobuf.pdf",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/51/2022-04-29T22%3A04%3A43.392216/Effective_Protobuf.pdf"
+    }
+  ],
+  "speakers": [
+    "Liran Haimovitch"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/Eb6y1WbF2is/maxresdefault.jpg",
+  "title": "Talk - Liran Haimovitch: Effective Protobuf: Everything You Wanted To Know, But Never Dared To Ask",
+  "videos": [
+    {
+      "length": 1651,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=Eb6y1WbF2is"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-liran-haimovitch-effective-protobuf-everything-you-wanted-to-know-but-never-dared-to-ask.json
+++ b/pycon-us-2022/videos/talk-liran-haimovitch-effective-protobuf-everything-you-wanted-to-know-but-never-dared-to-ask.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/Eb6y1WbF2is/maxresdefault.jpg",
-  "title": "Talk - Liran Haimovitch: Effective Protobuf: Everything You Wanted To Know, But Never Dared To Ask",
+  "title": "Effective Protobuf: Everything You Wanted To Know, But Never Dared To Ask",
   "videos": [
     {
       "length": 1651,

--- a/pycon-us-2022/videos/talk-maria-jose-molina-contreras-better-air-better-health-creating-an-indoor-air-quality.json
+++ b/pycon-us-2022/videos/talk-maria-jose-molina-contreras-better-air-better-health-creating-an-indoor-air-quality.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/FcDyMOSC9n0/maxresdefault.jpg",
-  "title": "Talk - Maria Jose Molina Contreras: Better Air, Better Health  Creating an indoor air quality...",
+  "title": "Better Air, Better Health: Creating an indoor air quality monitoring and predictive system.",
   "videos": [
     {
       "length": 1729,

--- a/pycon-us-2022/videos/talk-maria-jose-molina-contreras-better-air-better-health-creating-an-indoor-air-quality.json
+++ b/pycon-us-2022/videos/talk-maria-jose-molina-contreras-better-air-better-health-creating-an-indoor-air-quality.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "In the last couple of years, most people have been moved to a full working from home work-style, which made us realize benefits we were not aware of, but sadly some little inconveniences as well, like health related issues.\n\nIn this talk, we will explore how to build a functional system to track the air quality, collect our own data using different sensors and implement a predictive approach to avoid future health problems. We are going to dive into the different setups to interact with air quality sensors using Python on microcontrollers and embedded systems, collecting your own data to evaluate different factors like humidity, temperature, CO2, particles, but that\u2019s not all, also we will go into the implementation of a predictive machine learning (ML) model to predict Indoor CO2 levels and alerting us based on predictions before critical levels.\n\nThe main idea of this talk is to show with a practical example how Python is a great option to build an indoor air quality monitoring complemented with a predictive ML model for Indoor CO2, while having fun building and monitoring their home.",
+  "duration": 1729,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/70/2022-04-29T13%3A37%3A41.013632/pyconusv0-770998_3.pdf"
+    }
+  ],
+  "speakers": [
+    "Maria Jose Molina Contreras"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/FcDyMOSC9n0/maxresdefault.jpg",
+  "title": "Talk - Maria Jose Molina Contreras: Better Air, Better Health  Creating an indoor air quality...",
+  "videos": [
+    {
+      "length": 1729,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=FcDyMOSC9n0"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-mario-corchero-finding-penguins-with-a-snake-linux-features-for-a-python-user.json
+++ b/pycon-us-2022/videos/talk-mario-corchero-finding-penguins-with-a-snake-linux-features-for-a-python-user.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/nKDAuMjZs3s/hqdefault.jpg",
-  "title": "Talk - Mario Corchero: Finding penguins with a snake: Linux features for a Python user",
+  "title": "Finding penguins with a snake: Linux features for a Python user",
   "videos": [
     {
       "length": 1486,

--- a/pycon-us-2022/videos/talk-mario-corchero-finding-penguins-with-a-snake-linux-features-for-a-python-user.json
+++ b/pycon-us-2022/videos/talk-mario-corchero-finding-penguins-with-a-snake-linux-features-for-a-python-user.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Python has APIs that allow developers to use Linux features that many are often unaware of. If you are a modest Linux/Unix user and want to learn some features of the OS through the APIs that Python offers, this is the perfect talk with you. We will speak about processes, named pipes, fork and exec, inodes, and signals, among others, all whilst seeing how to play with these through the APIs that the Python standard library offers us.",
+  "duration": 1486,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Mario Corchero"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/nKDAuMjZs3s/hqdefault.jpg",
+  "title": "Talk - Mario Corchero: Finding penguins with a snake: Linux features for a Python user",
+  "videos": [
+    {
+      "length": 1486,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=nKDAuMjZs3s"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-maryanne-wachter-will-it-blend-writing-a-custom-constraint-solver-for-blender-with-cython.json
+++ b/pycon-us-2022/videos/talk-maryanne-wachter-will-it-blend-writing-a-custom-constraint-solver-for-blender-with-cython.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/TE3M3XfwSN4/hqdefault.jpg",
-  "title": "Talk - Maryanne Wachter: Will it Blend? Writing A Custom Constraint Solver for Blender with Cython",
+  "title": "Will it Blend? Writing A Custom Constraint Solver for Blender with Cython",
   "videos": [
     {
       "length": 1564,

--- a/pycon-us-2022/videos/talk-maryanne-wachter-will-it-blend-writing-a-custom-constraint-solver-for-blender-with-cython.json
+++ b/pycon-us-2022/videos/talk-maryanne-wachter-will-it-blend-writing-a-custom-constraint-solver-for-blender-with-cython.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Have you ever wanted to prove Python naysayers wrong in that you can have both fast and approachable code with Python? With a few adjustments to standard Python code, you can harness the power of Cython to vastly improve Python performance, while maintaining the look and feel of a traditional Python package. In this talk, common pitfalls in developing with Cython will be discussed in the context of how Cython was used to bring powerful and fast optimization algorithms to a custom geometric form finding add-on for Blender.",
+  "duration": 1564,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/109/2022-05-01T04%3A40%3A53.983171/PyCon_2022_-_Will_It_Blend_.pdf"
+    }
+  ],
+  "speakers": [
+    "Maryanne Wachter"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/TE3M3XfwSN4/hqdefault.jpg",
+  "title": "Talk - Maryanne Wachter: Will it Blend? Writing A Custom Constraint Solver for Blender with Cython",
+  "videos": [
+    {
+      "length": 1564,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=TE3M3XfwSN4"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-mason-egger-write-docs-devs-love-ten-tips-to-level-up-your-tech-writing.json
+++ b/pycon-us-2022/videos/talk-mason-egger-write-docs-devs-love-ten-tips-to-level-up-your-tech-writing.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/9WobKoE9OPI/hqdefault.jpg",
-  "title": "Talk - Mason Egger: Write Docs Devs Love: Ten Tips To Level Up Your Tech Writing",
+  "title": "Write Docs Devs Love: Ten Tips To Level Up Your Tech Writing",
   "videos": [
     {
       "length": 1617,

--- a/pycon-us-2022/videos/talk-mason-egger-write-docs-devs-love-ten-tips-to-level-up-your-tech-writing.json
+++ b/pycon-us-2022/videos/talk-mason-egger-write-docs-devs-love-ten-tips-to-level-up-your-tech-writing.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Think of that feeling you get when you follow an online tutorial or documentation and the code works on the first run. Now think of all the hours spent wasted following broken, outdated, or incomplete documentation. From our favorite tutorials to bad product docs we all consume technical writing. Tutorials, blog posts, and product docs help developers learn new things, build projects, and debug issues. But what makes one tutorial better than another? In this talk I'll discuss how you can write the documentation that developers love and I\u2019ll share 10 tips and tricks to improve your technical writing.",
+  "duration": 1617,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/173/2022-04-28T16%3A12%3A34.131557/Write_Docs_Devs_Love.pdf"
+    }
+  ],
+  "speakers": [
+    "Mason Egger"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/9WobKoE9OPI/hqdefault.jpg",
+  "title": "Talk - Mason Egger: Write Docs Devs Love: Ten Tips To Level Up Your Tech Writing",
+  "videos": [
+    {
+      "length": 1617,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=9WobKoE9OPI"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-meredydd-luff-building-a-python-code-completer.json
+++ b/pycon-us-2022/videos/talk-meredydd-luff-building-a-python-code-completer.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Code completion is almost magic, and it makes writing code feel so good. But how does it actually work? I built a code completion engine from scratch - and in this talk, I'll tell you its secrets.\n\nWe'll learn how Python parses and compiles code, what an AST is, and how we can use this knowledge to work out what a programmer might type next. And to prove it's not that complicated, I'll build a little code completer, live on stage, in about five minutes.\n\nI'll also talk about how code completion is like games programming, how we should broaden our thinking about \"types\" in Python, and how we can use information that isn't in your code to make coding even more satisfying.",
+  "duration": 1592,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Meredydd Luff"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/aRO7DkJrA_c/maxresdefault.jpg",
+  "title": "Talk - Meredydd Luff: Building a Python Code Completer",
+  "videos": [
+    {
+      "length": 1592,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=aRO7DkJrA_c"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-meredydd-luff-building-a-python-code-completer.json
+++ b/pycon-us-2022/videos/talk-meredydd-luff-building-a-python-code-completer.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/aRO7DkJrA_c/maxresdefault.jpg",
-  "title": "Talk - Meredydd Luff: Building a Python Code Completer",
+  "title": "Building a Python Code Completer",
   "videos": [
     {
       "length": 1592,

--- a/pycon-us-2022/videos/talk-miranda-auhl-animating-nfl-play-by-play-data-using-matplotlib-s-funcanimation.json
+++ b/pycon-us-2022/videos/talk-miranda-auhl-animating-nfl-play-by-play-data-using-matplotlib-s-funcanimation.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Most of us have heard the saying, \"A picture is worth a thousand words,\" but a movie builds context and a story, especially when conveying data! Data animations allow us to share more information and are far more engaging than static plots.\n\nIn this talk, I will discuss the importance of animation in analysis and show how to create data animations using play-by-play RFID data from the 2018 NFL season.\n\nWithin data science, we often use graphical representations of data to convey our analysis engagingly and succinctly. However, a static image does not always do justice to our findings and sometimes can miss important concepts entirely. When we introduce animation, we can show how location, statistics, etc., can change over time. Using this NFL play-by-play data, I will show how to take a static data plot and transform it into an animation using the matplotlib module.\n\nBy the end of this talk, you will know what data animation is, how it works for matplotlib using FuncAnimation(), how to animate plots successfully using defined functions in conjunction with your iterative function, and how animation can improve your analysis.",
+  "duration": 1494,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/25/2022-04-29T02%3A51%3A33.350370/PyCon_3.pdf"
+    }
+  ],
+  "speakers": [
+    "Miranda Auhl"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/rBZ7CAgIAu0/hqdefault.jpg",
+  "title": "Talk - Miranda Auhl: Animating NFL play by play data using matplotlib's FuncAnimation()",
+  "videos": [
+    {
+      "length": 1494,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=rBZ7CAgIAu0"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-miranda-auhl-animating-nfl-play-by-play-data-using-matplotlib-s-funcanimation.json
+++ b/pycon-us-2022/videos/talk-miranda-auhl-animating-nfl-play-by-play-data-using-matplotlib-s-funcanimation.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/rBZ7CAgIAu0/hqdefault.jpg",
-  "title": "Talk - Miranda Auhl: Animating NFL play by play data using matplotlib's FuncAnimation()",
+  "title": "Animating NFL play by play data using matplotlib's FuncAnimation()",
   "videos": [
     {
       "length": 1494,

--- a/pycon-us-2022/videos/talk-mohammad-athar-d-d-and-g-a-daring-tale-of-dungeons-and-dragons-and-also-graph.json
+++ b/pycon-us-2022/videos/talk-mohammad-athar-d-d-and-g-a-daring-tale-of-dungeons-and-dragons-and-also-graph.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "This talk will take the form of a story of adventurers who meet in tavern, and use graph algorithms to chase down a McGuffin. The goal is to develop an intuition-first understanding of common graph algorithms.\nTarget audience is primarily programmers who want to review, or better understand graph algorithms.\nI will show how to convert mazes, social networks, and maps in to graphs. I will also cover eight algorithms- BFS, DFS, Dijkstra's, Hierholzer's, articulation points, centrality, Kruskal's algorithm, and the Louvain method. I will also provide practical (as practical as D&D can get) applications for these algorithms.",
+  "duration": 1407,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Mohammad Athar"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/t2EUocx3vGQ/maxresdefault.jpg",
+  "title": "Talk - Mohammad Athar: D&D and G - a daring tale of Dungeons and Dragons and also Graph",
+  "videos": [
+    {
+      "length": 1407,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=t2EUocx3vGQ"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-mohammad-athar-d-d-and-g-a-daring-tale-of-dungeons-and-dragons-and-also-graph.json
+++ b/pycon-us-2022/videos/talk-mohammad-athar-d-d-and-g-a-daring-tale-of-dungeons-and-dragons-and-also-graph.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/t2EUocx3vGQ/maxresdefault.jpg",
-  "title": "Talk - Mohammad Athar: D&D and G - a daring tale of Dungeons and Dragons and also Graph",
+  "title": "D&D and G - a daring tale of Dungeons and Dragons and also Graph",
   "videos": [
     {
       "length": 1407,

--- a/pycon-us-2022/videos/talk-moshe-zadka-best-practices-for-continuous-integration-in-python-v02.json
+++ b/pycon-us-2022/videos/talk-moshe-zadka-best-practices-for-continuous-integration-in-python-v02.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/HMlXSiDKWrg/maxresdefault.jpg",
-  "title": "Talk - Moshe Zadka: Best Practices for Continuous Integration in Python V02",
+  "title": "Best Practices for Continuous Integration in Python V02",
   "videos": [
     {
       "length": 1653,

--- a/pycon-us-2022/videos/talk-moshe-zadka-best-practices-for-continuous-integration-in-python-v02.json
+++ b/pycon-us-2022/videos/talk-moshe-zadka-best-practices-for-continuous-integration-in-python-v02.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "It is now accepted that having continuous integration is a best practice for almost all non-trivial projects. But configuring CI for Python correctly is still hard. The solution space is big, many common configurations work around the bugs and limitations that existed in past CI systems, and there are few explanations about how to do it well.\n\nA good CI configuration concentrates on giving timely and accurate feedback to the developer. Whether it is using GitHub Actions, GitLab CI/CD, Jenkins, or something else, there are ways to configure the system to be more accurate and faster.",
+  "duration": 1653,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Moshe Zadka"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/HMlXSiDKWrg/maxresdefault.jpg",
+  "title": "Talk - Moshe Zadka: Best Practices for Continuous Integration in Python V02",
+  "videos": [
+    {
+      "length": 1653,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=HMlXSiDKWrg"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-nandita-viswanath-and-sagar-aryal-in-house-to-open-source-stitching-the-past-to-the-futu.json
+++ b/pycon-us-2022/videos/talk-nandita-viswanath-and-sagar-aryal-in-house-to-open-source-stitching-the-past-to-the-futu.json
@@ -16,7 +16,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/axFE61Idn6U/hqdefault.jpg",
-  "title": "Talk - Nandita Viswanath/Sagar Aryal: In house to open source: Stitching the past to the futu...",
+  "title": "In-house to open source: Stitching the past to the future with Python",
   "videos": [
     {
       "length": 1538,

--- a/pycon-us-2022/videos/talk-nandita-viswanath-and-sagar-aryal-in-house-to-open-source-stitching-the-past-to-the-futu.json
+++ b/pycon-us-2022/videos/talk-nandita-viswanath-and-sagar-aryal-in-house-to-open-source-stitching-the-past-to-the-futu.json
@@ -1,0 +1,27 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Ever had to deal with old code that is filled with thousands of repetitive code blocks and too many if statements? It gets harder when the original authors aren't around to explain what they were thinking. These pain points related to legacy software are often the motivation for many organizations to adopt robust open source solutions. Open source software is becoming more and more the standard in any tech stack. Knowing how to navigate the world of open source software and how to best implement it is a skill that is becoming ever more important for any software engineer. Python is one of the most popular languages when it comes to open source. In this talk, we hope to outline why this is and how you can take advantage of it in your software migrations.",
+  "duration": 1538,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Nandita Viswanath",
+    "Sagar Aryal"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/axFE61Idn6U/hqdefault.jpg",
+  "title": "Talk - Nandita Viswanath/Sagar Aryal: In house to open source: Stitching the past to the futu...",
+  "videos": [
+    {
+      "length": 1538,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=axFE61Idn6U"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-nir-barazida-dock-your-jupyter-notebook.json
+++ b/pycon-us-2022/videos/talk-nir-barazida-dock-your-jupyter-notebook.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/mBSb0BjSJps/hqdefault.jpg",
-  "title": "Talk - Nir Barazida: Dock Your Jupyter Notebook",
+  "title": "Dock Your Jupyter Notebook",
   "videos": [
     {
       "length": 1323,

--- a/pycon-us-2022/videos/talk-nir-barazida-dock-your-jupyter-notebook.json
+++ b/pycon-us-2022/videos/talk-nir-barazida-dock-your-jupyter-notebook.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "To perfect your Jupyter Notebook craft, you'd want to make your work reproducible and shareable outside your local machine. In this talk, we will learn how to use Docker to build an isolated and pre-defined environment suited for ML project that runs smoothly on a remote machine.",
+  "duration": 1323,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Nir Barazida"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/mBSb0BjSJps/hqdefault.jpg",
+  "title": "Talk - Nir Barazida: Dock Your Jupyter Notebook",
+  "videos": [
+    {
+      "length": 1323,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=mBSb0BjSJps"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-olivier-breuleux-how-to-change-python-while-it-s-running.json
+++ b/pycon-us-2022/videos/talk-olivier-breuleux-how-to-change-python-while-it-s-running.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Wouldn't it be nice to be able to do live development in a running Python instance, using your favorite editor and structuring your code however you would like, seeing your changes immediately reflected in the middle of the program's execution? Thanks to Python's incredible runtime flexibility, this can be done. In this talk, we will explore how changes to source code files can be integrated into running programs, covering as many edge cases as possible and explaining the intrinsic limitations of the approach. We will also demonstrate Jurigged, a flexible and extensible working implementation of this system.",
+  "duration": 1820,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/26/2022-04-30T21%3A55%3A53.200731/How_to_change_Python.pdf"
+    }
+  ],
+  "speakers": [
+    "Olivier Breuleux"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/t8pB8dbi2qc/maxresdefault.jpg",
+  "title": "Talk - Olivier Breuleux: How to change Python (while it's running)",
+  "videos": [
+    {
+      "length": 1820,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=t8pB8dbi2qc"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-olivier-breuleux-how-to-change-python-while-it-s-running.json
+++ b/pycon-us-2022/videos/talk-olivier-breuleux-how-to-change-python-while-it-s-running.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/t8pB8dbi2qc/maxresdefault.jpg",
-  "title": "Talk - Olivier Breuleux: How to change Python (while it's running)",
+  "title": "How to change Python (while it's running)",
   "videos": [
     {
       "length": 1820,

--- a/pycon-us-2022/videos/talk-pablo-alcain-software-development-for-machine-learning-in-python.json
+++ b/pycon-us-2022/videos/talk-pablo-alcain-software-development-for-machine-learning-in-python.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/JmhDYREyj34/hqdefault.jpg",
-  "title": "Talk - Pablo Alcain: Software Development for Machine Learning in Python",
+  "title": "Software Development for Machine Learning in Python",
   "videos": [
     {
       "length": 2227,

--- a/pycon-us-2022/videos/talk-pablo-alcain-software-development-for-machine-learning-in-python.json
+++ b/pycon-us-2022/videos/talk-pablo-alcain-software-development-for-machine-learning-in-python.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Machine Learning and Data Science code has its own set of challenges and peculiarities. When we write code to be used by Data Scientists or Machine Learning Developers we have to keep in mind constantly that every abstraction we use has to a) be compatible with a fast and easy exploration playground; b) allow for sensible checkpoints and optimizations; c) implement in a declarative fashion repeated queries and functions; and d) provide an abstraction level over all of the production code so it can be tracked and monitored seamlessly.\n\nIn this talk we will provide general guidelines to approach this problem from a software engineering perspective, defining what should our entities be, how deep should our abstraction go and how to avoid some usual design pitfalls. We will apply all these guidelines to a specific and small end to end problem.",
+  "duration": 2227,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/2/2022-05-05T19%3A50%3A59.469490/Software_Development_for_Machine_Learni_tbMu5bk.pdf"
+    }
+  ],
+  "speakers": [
+    "Pablo Alcain"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/JmhDYREyj34/hqdefault.jpg",
+  "title": "Talk - Pablo Alcain: Software Development for Machine Learning in Python",
+  "videos": [
+    {
+      "length": 2227,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=JmhDYREyj34"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-pablo-galindo-salgado-making-python-better-one-error-message-at-a-time.json
+++ b/pycon-us-2022/videos/talk-pablo-galindo-salgado-making-python-better-one-error-message-at-a-time.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/5eYOQxqqWl8/hqdefault.jpg",
-  "title": "Talk - Pablo Galindo Salgado: Making Python better one error message at a time",
+  "title": "Making Python better one error message at a time",
   "videos": [
     {
       "length": 1545,

--- a/pycon-us-2022/videos/talk-pablo-galindo-salgado-making-python-better-one-error-message-at-a-time.json
+++ b/pycon-us-2022/videos/talk-pablo-galindo-salgado-making-python-better-one-error-message-at-a-time.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Python 3.10 has been recently released and among many exciting new features, one of the biggest improvements is the inclusion of a whole new set of changes focused on improving the error messages across the interpreter and the general user experience when dealing with error messages. The new error messages have been one of the most welcomed features from very different sets of users ranging from Python teachers and educators, first-time learners, industry professionals and data scientists.\n\nIn this talk, we will cover:\n\nWhat are the new improvements featured in Python 3.10.\nExciting new changes and improvements that will feature in Python 3.11.\nHow these improvements are useful to different sets of users from people learning Python to experienced programmers.\nHow the new PEG parser has unlocked adding new custom syntax errors.\nHow these improvements were implemented and what challenges the CPython core team faced to get them working reliably.\nHow users can contribute to adding new error messages: what is the workflow, how the errors are reviewed by the core team and where to find resources and help.\nNo matter who you are and what you do with Python, there is an improvement that will probably make you smile.",
+  "duration": 1545,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Pablo Galindo Salgado"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/5eYOQxqqWl8/hqdefault.jpg",
+  "title": "Talk - Pablo Galindo Salgado: Making Python better one error message at a time",
+  "videos": [
+    {
+      "length": 1545,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=5eYOQxqqWl8"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-padmaja-bhagwat-manisha-r-vignet-an-intelligent-camera-app-that-assists-you.json
+++ b/pycon-us-2022/videos/talk-padmaja-bhagwat-manisha-r-vignet-an-intelligent-camera-app-that-assists-you.json
@@ -24,7 +24,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/f6BWDWpCXug/hqdefault.jpg",
-  "title": "Talk - Padmaja Bhagwat/Manisha R: VigNET: An intelligent camera app that assists you...",
+  "title": "VigNET: An intelligent camera app that assists you in understanding your surroundings",
   "videos": [
     {
       "length": 1654,

--- a/pycon-us-2022/videos/talk-padmaja-bhagwat-manisha-r-vignet-an-intelligent-camera-app-that-assists-you.json
+++ b/pycon-us-2022/videos/talk-padmaja-bhagwat-manisha-r-vignet-an-intelligent-camera-app-that-assists-you.json
@@ -1,0 +1,35 @@
+{
+  "copyright_text": "CC BY",
+  "description": "What if you can understand your surroundings with just a click of a picture?\n\nThe speakers have built an intelligent camera app that assists people with visual impairment in understanding their surroundings. This application takes camera input in the form of an image and attempts to answer questions related to the image. Simply put, it's a Visual Question Answering (VQA) app.\n\nThe deep learning based application is built using a transformer based model called Vision Language Transformer (ViLT) which is both computationally fast and efficient, thus providing answers to users\u2019 questions within a fraction of seconds. The application is integrated with speech-to-text and text-to-speech capabilities to enhance accessibility.\n\nThis talk would mainly cover the following: * What is the Vision Language Transformer (ViLT) model? * Advantages of ViLT over traditional vision language pre-trained models * Best practices around modularizing the application into different services * Steps to deploy this deep learning based application on cloud (GCP) * How in-built python libraries helped in implementing and deploying such complex models (viz. ViLT) easily\n\nThe entire code is open-sourced and the talk will provide a walkthrough of the steps to build your own visual question answering application.",
+  "duration": 1654,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/83/2022-04-29T03%3A09%3A38.147066/PyCon2022.pdf"
+    },
+    {
+      "label": "Demo",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/83/2022-04-29T03%3A05%3A47.986467/vignet_demo.mp4"
+    }
+  ],
+  "speakers": [
+    "Padmaja Bhagwat",
+    "Manisha R"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/f6BWDWpCXug/hqdefault.jpg",
+  "title": "Talk - Padmaja Bhagwat/Manisha R: VigNET: An intelligent camera app that assists you...",
+  "videos": [
+    {
+      "length": 1654,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=f6BWDWpCXug"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-pandy-knight-managing-the-test-data-nightmare.json
+++ b/pycon-us-2022/videos/talk-pandy-knight-managing-the-test-data-nightmare.json
@@ -1,6 +1,6 @@
 {
   "copyright_text": "CC BY",
-  "description": "Good data for testing can be a nightmare to manage. Sometimes, teams don\u2019t have much control over the data in their systems under test\u2014it\u2019s just dropped in, and it can change arbitrarily. Other times, teams need to build their own data sets, either before testing or during testing. Inaccurate data can leave test gaps. Incorrect or stale data can break tests. Large data can consume too much time. Ugh!\n\nIn this talk, we\u2019ll cover strategies for defeating many types of test data nightmares:\n\nrecognizing the difference between product data and test case data\ndeciding when to prepare data statically beforehand or dynamically during testing\nusing data to control how tests run or reflect product state\nhard-coding values versus discovering data in the system\navoiding collisions on shared data\nThe strategies we cover can be applied to any project in any language. After this talk, you will wake up from the nightmare and handle test data cleanly and efficiently like a pro!",
+  "description": "Good data for testing can be a nightmare to manage. Sometimes, teams don\u2019t have much control over the data in their systems under test\u2014it\u2019s just dropped in, and it can change arbitrarily. Other times, teams need to build their own data sets, either before testing or during testing. Inaccurate data can leave test gaps. Incorrect or stale data can break tests. Large data can consume too much time. Ugh!\n\nIn this talk, we\u2019ll cover strategies for defeating many types of test data nightmares:\n\n- recognizing the difference between product data and test case data\n- deciding when to prepare data statically beforehand or dynamically during testing\n- using data to control how tests run or reflect product state\n- hard-coding values versus discovering data in the system\n- avoiding collisions on shared data\n\nThe strategies we cover can be applied to any project in any language. After this talk, you will wake up from the nightmare and handle test data cleanly and efficiently like a pro!",
   "duration": 1734,
   "language": "eng",
   "recorded": "2022-04-27",
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/6DQhfjq_HSI/hqdefault.jpg",
-  "title": "Talk - Pandy Knight: Managing the Test Data Nightmare",
+  "title": "Managing the Test Data Nightmare",
   "videos": [
     {
       "length": 1734,

--- a/pycon-us-2022/videos/talk-pandy-knight-managing-the-test-data-nightmare.json
+++ b/pycon-us-2022/videos/talk-pandy-knight-managing-the-test-data-nightmare.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Good data for testing can be a nightmare to manage. Sometimes, teams don\u2019t have much control over the data in their systems under test\u2014it\u2019s just dropped in, and it can change arbitrarily. Other times, teams need to build their own data sets, either before testing or during testing. Inaccurate data can leave test gaps. Incorrect or stale data can break tests. Large data can consume too much time. Ugh!\n\nIn this talk, we\u2019ll cover strategies for defeating many types of test data nightmares:\n\nrecognizing the difference between product data and test case data\ndeciding when to prepare data statically beforehand or dynamically during testing\nusing data to control how tests run or reflect product state\nhard-coding values versus discovering data in the system\navoiding collisions on shared data\nThe strategies we cover can be applied to any project in any language. After this talk, you will wake up from the nightmare and handle test data cleanly and efficiently like a pro!",
+  "duration": 1734,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Pandy Knight"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/6DQhfjq_HSI/hqdefault.jpg",
+  "title": "Talk - Pandy Knight: Managing the Test Data Nightmare",
+  "videos": [
+    {
+      "length": 1734,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=6DQhfjq_HSI"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-paul-ganssle-what-to-do-when-the-bug-is-in-someone-else-s-code.json
+++ b/pycon-us-2022/videos/talk-paul-ganssle-what-to-do-when-the-bug-is-in-someone-else-s-code.json
@@ -19,7 +19,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/LTMguK-XJEo/maxresdefault.jpg",
-  "title": "Talk - Paul Ganssle: What to Do When the Bug Is in Someone Else's Code",
+  "title": "What to Do When the Bug Is in Someone Else's Code",
   "videos": [
     {
       "length": 1831,

--- a/pycon-us-2022/videos/talk-paul-ganssle-what-to-do-when-the-bug-is-in-someone-else-s-code.json
+++ b/pycon-us-2022/videos/talk-paul-ganssle-what-to-do-when-the-bug-is-in-someone-else-s-code.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "It's generally better to use libraries than to write your own code, but what happens when you run into an issue that is correctly solved by modifying the library code rather than your own code? What if you need to deploy a fix today, but you can't count on the upstream library applying the required fixes and getting a new release through your deployment system before your deadline? This presentation will cover various stop-gap strategies (of varying desirability) for dealing with this situation, including:\n\n- Working around the bug with wrapper functions\n- Monkey patching the offending methods or functions\n- Vendoring a patched version of the library into your application\n- Maintaining a forked version in your local package manager",
+  "duration": 1831,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/86/2022-04-27T18%3A09%3A54.168666/What_to_Do_When_the_Bug_is_in_Someone__vLd1Knp.pdf"
+    }
+  ],
+  "speakers": [
+    "Paul Ganssle"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/LTMguK-XJEo/maxresdefault.jpg",
+  "title": "Talk - Paul Ganssle: What to Do When the Bug Is in Someone Else's Code",
+  "videos": [
+    {
+      "length": 1831,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=LTMguK-XJEo"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-paul-kehrer-alex-gaynor-shipping-python-extensions-in-rust-two-million-times-a-day.json
+++ b/pycon-us-2022/videos/talk-paul-kehrer-alex-gaynor-shipping-python-extensions-in-rust-two-million-times-a-day.json
@@ -16,7 +16,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/z_Eiy2W0APU/maxresdefault.jpg",
-  "title": "Talk - Paul Kehrer/Alex Gaynor: Shipping Python Extensions in Rust Two Million Times a Day",
+  "title": "Shipping Python Extensions in Rust Two Million Times a Day",
   "videos": [
     {
       "length": 1581,

--- a/pycon-us-2022/videos/talk-paul-kehrer-alex-gaynor-shipping-python-extensions-in-rust-two-million-times-a-day.json
+++ b/pycon-us-2022/videos/talk-paul-kehrer-alex-gaynor-shipping-python-extensions-in-rust-two-million-times-a-day.json
@@ -1,0 +1,27 @@
+{
+  "copyright_text": "CC BY",
+  "description": "For as long as Python has been around, a strength has been the ecosystem of packages written not in Python, but in C -- whether that's PIL, or numpy, or simplejson, or one of the thousands of others. But why C? Why not some other language? In the last several years, Rust has emerged as a serious competitor to C. This talk will explore how we went about the process of using Rust in the pyca/cryptography package, the challenges we faced, the successes we found, and what this means for your projects.",
+  "duration": 1581,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Paul Kehrer",
+    "Alex Gaynor"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/z_Eiy2W0APU/maxresdefault.jpg",
+  "title": "Talk - Paul Kehrer/Alex Gaynor: Shipping Python Extensions in Rust Two Million Times a Day",
+  "videos": [
+    {
+      "length": 1581,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=z_Eiy2W0APU"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-paul-vincent-craven-harvest-the-power-of-the-gpu-for-awesome-special-effects.json
+++ b/pycon-us-2022/videos/talk-paul-vincent-craven-harvest-the-power-of-the-gpu-for-awesome-special-effects.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "This talk will show the impressive graphics you can create with OpenGL shaders. The Arcade library makes it easy to take many of the examples shown on the popular www.shadertoy.com website and run them under Python. We'll explain how shaders work, why they are so fast, and how to get started integrating shaders into your own Python programs.",
+  "duration": 1540,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Paul Vincent Craven"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/JP6EnuQT2wA/maxresdefault.jpg",
+  "title": "Talk - Paul Vincent Craven: Harvest the power of the GPU for awesome special effects",
+  "videos": [
+    {
+      "length": 1540,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=JP6EnuQT2wA"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-paul-vincent-craven-harvest-the-power-of-the-gpu-for-awesome-special-effects.json
+++ b/pycon-us-2022/videos/talk-paul-vincent-craven-harvest-the-power-of-the-gpu-for-awesome-special-effects.json
@@ -15,7 +15,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/JP6EnuQT2wA/maxresdefault.jpg",
-  "title": "Talk - Paul Vincent Craven: Harvest the power of the GPU for awesome special effects",
+  "title": "Harvest the power of the GPU for awesome special effects",
   "videos": [
     {
       "length": 1540,

--- a/pycon-us-2022/videos/talk-peacock-getting-started-with-statically-typed-programming-in-python-3-10.json
+++ b/pycon-us-2022/videos/talk-peacock-getting-started-with-statically-typed-programming-in-python-3-10.json
@@ -23,7 +23,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/ZUIK9hxyi7Y/maxresdefault.jpg",
-  "title": "Talk - Peacock: Getting Started with Statically Typed Programming in Python 3.10",
+  "title": "Getting Started with Statically Typed Programming in Python 3.10",
   "videos": [
     {
       "length": 1720,

--- a/pycon-us-2022/videos/talk-peacock-getting-started-with-statically-typed-programming-in-python-3-10.json
+++ b/pycon-us-2022/videos/talk-peacock-getting-started-with-statically-typed-programming-in-python-3-10.json
@@ -1,0 +1,34 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Since 2015, it has been possible to write Python like a statically typed language with typing modules and other features introduced in Python 3.5.\n\nThis can significantly improve the development experience and review process.\n\nI have been using type hints in my work for several years and have been studying Haskell and TypeScirpt. I believe this session will be a stepping stone for \"type hints newbies.\"\n\nWhat I will talk about in this talk:\n\n- Advantages of using Typing\n- Getting help from editors\n- Facilitating code reviews\n- How to get started with Typing\n- Argument and return types for functions\n- Using the standard Collections types\n- The difference between tuple and other types\n- Abstract and concrete types\n- Generics, user-defined types\n- Type Hinting Updates in Python 3.9 and 3.10\n- (3.9) Type Hinting Generics In Standard Collections\n- (3.10) Allow writing union types as X | Y\n- (3.10) Parameter Specification Variables\n- (3.10) Explicit Type Aliases\n- (3.10) User-Defined Type Guards\n\nWhat is not covered in this talk\n\n- Basic Python 3 syntax\n- (Not required): Experience developing in statically typed languages\n\nRelated contents:\n\n- A talk at PyCon JP 2020 (JA): https://pycon.jp/2020/en/timetable/?id=203955\n- https://docs.python.org/3/library/typing.html",
+  "duration": 1720,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "A talk at PyCon JP 2020 (JA)",
+      "url": "https://pycon.jp/2020/en/timetable/?id=203955"
+    },
+    {
+      "label": "https://docs.python.org/3/library/typing.html",
+      "url": "https://docs.python.org/3/library/typing.html"
+    }
+  ],
+  "speakers": [
+    "Peacock"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/ZUIK9hxyi7Y/maxresdefault.jpg",
+  "title": "Talk - Peacock: Getting Started with Statically Typed Programming in Python 3.10",
+  "videos": [
+    {
+      "length": 1720,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=ZUIK9hxyi7Y"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-reka-ben-actionable-insights-vs-ranking-how-to-use-and-how-not-to-use-code-quality-metrics.json
+++ b/pycon-us-2022/videos/talk-reka-ben-actionable-insights-vs-ranking-how-to-use-and-how-not-to-use-code-quality-metrics.json
@@ -26,7 +26,7 @@
     "talk"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/N_hgD1eA7ks/maxresdefault.jpg",
-  "title": "Talk - Reka/Ben: Actionable insights vs ranking How to use and how NOT to use code quality metrics",
+  "title": "Actionable insights vs ranking: How to use and how NOT to use code quality metrics?",
   "videos": [
     {
       "length": 1676,

--- a/pycon-us-2022/videos/talk-reka-ben-actionable-insights-vs-ranking-how-to-use-and-how-not-to-use-code-quality-metrics.json
+++ b/pycon-us-2022/videos/talk-reka-ben-actionable-insights-vs-ranking-how-to-use-and-how-not-to-use-code-quality-metrics.json
@@ -1,0 +1,37 @@
+{
+  "copyright_text": "CC BY",
+  "description": "In this talk, we want to make two major points:\n\n- Metrics can facilitate better conversation about code quality. They help you focus more on technical problems and improvements instead of personal preferences and organizational issues.\n- Metrics can be misused very easily. Knowing their limitations is crucial.\n\nMETRICS\n\nFor each metric, we'll discuss:\n\n- code examples in Python\n- how to calculate\n- interpretation (incl. some comparison across open source Python projects)\n- actions\n- limitations\n\nMETHOD LENGTH\n\nThe simple.\n\nYou can calculate it without specific tools.\nFirst step: Extract functions.\nIt shows well some general limitations of code quality metrics.\n\nCYCLOMATIC COMPLEXITY\n\nThe old.\n\nShow the formula, but don't explain it in detail. :-)\nExtract functions. Remove redundant if conditions.\nIt doesn't account for nested coding constructs. It ignores some modern language patterns.\n\nCOGNITIVE COMPLEXITY\n\nThe human.\n\nCalculation and interpretation: see https://www.sonarsource.com/docs/CognitiveComplexity.pdf\nActions: Extract functions. Use shorthand structures. More Pythonic code is also more readable.\nLimitations: It ignores both the length of a linear block and the complexity of the expressions used in it.\n\nWORKING MEMORY\n\nAnother aspect of human understanding.\n\nCalculation: see https://sourcery.ai/blog/working-memory/\nInterpretation: The 7 +/- 2 rule of the human working memory.\nActions: Extract functions, some more specific refactorings this metric rewards.\nLimitations: It ignores the structure.\n\nLIMITATIONS AND PITFALLS\n\nGENERAL\n\n- They can be gamed.\n- They easily encourage one-sided thinking and behaviour.\n\nSPECIFIC FOR CODE QUALITY METRICS\n\n- Great as warning signs, not good as \"proof of excellence\".\n\nCOMPOUND METRICS\n\n- Giving a more versatile picture than a single metric.\n\nWHAT METRICS DON'T CAPTURE\n\n- naming, consistent terminology, ubiquitous language (DDD)\n- project structure\n- correctness",
+  "duration": 1676,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Calculation and interpretation",
+      "url": "https://www.sonarsource.com/docs/CognitiveComplexity.pdf"
+    },
+    {
+      "label": "Calculation",
+      "url": "https://sourcery.ai/blog/working-memory/"
+    }
+  ],
+  "speakers": [
+    "Reka",
+    "Ben"
+  ],
+  "tags": [
+    "talk"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/N_hgD1eA7ks/maxresdefault.jpg",
+  "title": "Talk - Reka/Ben: Actionable insights vs ranking How to use and how NOT to use code quality metrics",
+  "videos": [
+    {
+      "length": 1676,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=N_hgD1eA7ks"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-reuven-m-lerner-understanding-attributes-or-they-re-not-nearly-as-boring-as-you-think.json
+++ b/pycon-us-2022/videos/talk-reuven-m-lerner-understanding-attributes-or-they-re-not-nearly-as-boring-as-you-think.json
@@ -1,0 +1,32 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Attributes in Python, which we use dozens of times each day, seem boring, obvious, and not worthy of attention. But it turns out that they're key to the Python language: Every time you say a.b in Python, that little dot is hiding a lot of work, from searching across multiple objects to silently rewriting things. And it turns out that what happens with attributes, while not always obvious to developers, determines a great deal of behavior in the Python language.\n\nIn this talk, I'll discuss what attributes are (and aren't), what Python does when you use a dot (.) in your code, and how you can take advantage of it. We'll talk about attribute lookup, about inheritance, and about methods vs. functions. We'll also look into properties, and how they allow us to have attributes that look like data but behave like setters and getters. Finally, we'll look at the descriptor protocol, which makes so much of Python's functionality possible, including the automatic insertion of \"self\" as the first argument in method calls.",
+  "duration": 2259,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/22/2022-05-01T04%3A08%3A16.996945/Presentation__Python_attributes.key.pdf"
+    }
+  ],
+  "speakers": [
+    "Reuven M. Lerner"
+  ],
+  "tags": [
+    "talk"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/Tn1wLsj7Bys/maxresdefault.jpg",
+  "title": "Talk - Reuven M. Lerner: Understanding attributes (Or: They're not nearly as boring as you think!)",
+  "videos": [
+    {
+      "length": 2259,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=Tn1wLsj7Bys"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-reuven-m-lerner-understanding-attributes-or-they-re-not-nearly-as-boring-as-you-think.json
+++ b/pycon-us-2022/videos/talk-reuven-m-lerner-understanding-attributes-or-they-re-not-nearly-as-boring-as-you-think.json
@@ -21,7 +21,7 @@
     "talk"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/Tn1wLsj7Bys/maxresdefault.jpg",
-  "title": "Talk - Reuven M. Lerner: Understanding attributes (Or: They're not nearly as boring as you think!)",
+  "title": "Understanding attributes (Or: They're not nearly as boring as you think!)",
   "videos": [
     {
       "length": 2259,

--- a/pycon-us-2022/videos/talk-richard-taggart-leveraging-a-custom-cpython-data-model-for-high-performance.json
+++ b/pycon-us-2022/videos/talk-richard-taggart-leveraging-a-custom-cpython-data-model-for-high-performance.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Developing insights for problems encountered while building a high-performance microprocessor requires analyzing large amounts of data generated from a complicated design process. This is a Big Data problem. The four main challenges include: managing design components, reporting, linking data across time, and providing a reliable and scalable platform. The Design Data (DD) data model is a technological breakthrough to address the above challenges for integrated circuit design, analysis, and debug. The data model efficiently stores read-only design graph topology (e.g., inter-connected logic gates and wires), and derived analysis data (e.g., estimated signal delay and power usage) in a compressed binary file. DD is a custom domain-specific read-only binary data model with an extensive query API, which is implemented using C++, CPython, and Python method bindings.\n\nThe C++ data model implementation enables efficient graph traversal, custom interactive \"offline\" analysis, and design graph visualization. Every data file may be tagged and stored using the compressible binary format, which facilitates comparing different versions across a multi-year project. They can compare past and current data sets to identify and assess specific design trends and failure modes. This data analysis workflow powered by Python improves the quality of a chip design by allowing engineers to focus on the hard problems.\n\nThis talk will share our experience of incorporating modern Free Open-Source Software technologies into a complicated ecosystem of commercial toolchains and workflows for Electronic Design Automation (EDA). After this talk, I hope you will be inspired to experiment with integrating C or C++ and CPython bindings into your application workflow. I also hope this may help you think about different ways you might be able to integrate various methods of Data Science into your application domain.",
+  "duration": 1344,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Richard Taggart"
+  ],
+  "tags": [
+    "talk"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/mbssZpB7U50/maxresdefault.jpg",
+  "title": "Talk - Richard Taggart: Leveraging a custom CPython data model for high performance...",
+  "videos": [
+    {
+      "length": 1344,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=mbssZpB7U50"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-richard-taggart-leveraging-a-custom-cpython-data-model-for-high-performance.json
+++ b/pycon-us-2022/videos/talk-richard-taggart-leveraging-a-custom-cpython-data-model-for-high-performance.json
@@ -17,7 +17,7 @@
     "talk"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/mbssZpB7U50/maxresdefault.jpg",
-  "title": "Talk - Richard Taggart: Leveraging a custom CPython data model for high performance...",
+  "title": "Leveraging a custom CPython data model for high-performance microprocessor design",
   "videos": [
     {
       "length": 1344,

--- a/pycon-us-2022/videos/talk-roman-yurchak-hood-chatham-pyodide-a-python-distribution-for-the-browser.json
+++ b/pycon-us-2022/videos/talk-roman-yurchak-hood-chatham-pyodide-a-python-distribution-for-the-browser.json
@@ -18,7 +18,7 @@
     "talk"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/6u2pqQ4pC04/hqdefault.jpg",
-  "title": "Talk - Roman Yurchak/Hood Chatham: Pyodide: A Python distribution for the browser",
+  "title": "Pyodide: A Python distribution for the browser",
   "videos": [
     {
       "length": 2471,

--- a/pycon-us-2022/videos/talk-roman-yurchak-hood-chatham-pyodide-a-python-distribution-for-the-browser.json
+++ b/pycon-us-2022/videos/talk-roman-yurchak-hood-chatham-pyodide-a-python-distribution-for-the-browser.json
@@ -1,0 +1,29 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Pyodide is a Python distribution for the browser and Node.js based on WebAssembly. It includes a port of CPython 3.9 to WebAssembly/Emscripten, and makes it possible to install and run Python packages in the browser. Pyodide comes with a robust Javascript \u27fa Python foreign function interface so that you can mix these two languages in your code with minimal friction.\n\nWe will walk through simple examples of how to run Python applications in the browser with Pyodide. We will also discuss the process of porting existing Python packages, including what makes a package suitable to port and what challenges are likely to arise.\n\nSome Criteria that Determine Suitability of a Project for Porting:\n\nPurely computational projects are simple to port to run in the browser. We are missing threading and multiprocessing, so you will need to be able to run single threaded. File system code mostly works unchanged. However, much of the UI and network access are very different inside the browser. Packages with a clean divide between doing computation and doing UI will be simpler to port, the UI parts may need to be rewritten or shimmed but the pure computation need not be.",
+  "duration": 2471,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Roman Yurchak",
+    "Hood Chatham"
+  ],
+  "tags": [
+    "talk"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/6u2pqQ4pC04/hqdefault.jpg",
+  "title": "Talk - Roman Yurchak/Hood Chatham: Pyodide: A Python distribution for the browser",
+  "videos": [
+    {
+      "length": 2471,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=6u2pqQ4pC04"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-ryan-kuhl-graphql-the-devil-s-api.json
+++ b/pycon-us-2022/videos/talk-ryan-kuhl-graphql-the-devil-s-api.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "While there are advantages to using GraphQL vs. traditional REST APIs such as descriptive queries, there are also a plethora of potential pitfalls, such as the n+1 query problem and idiosyncratic fickleness. We leverage data-loaders, async/await, dynamic query generation, and other performance optimizations in GraphQL to create a flexible, performant interface for our front-end services. Let\u2019s do GraphQL the right way!",
+  "duration": 2242,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Ryan Kuhl"
+  ],
+  "tags": [
+    "talk"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/U6tZT1_3dxM/hqdefault.jpg",
+  "title": "Talk - Ryan Kuhl: GraphQL The Devil's API",
+  "videos": [
+    {
+      "length": 2242,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=U6tZT1_3dxM"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-ryan-kuhl-graphql-the-devil-s-api.json
+++ b/pycon-us-2022/videos/talk-ryan-kuhl-graphql-the-devil-s-api.json
@@ -17,7 +17,7 @@
     "talk"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/U6tZT1_3dxM/hqdefault.jpg",
-  "title": "Talk - Ryan Kuhl: GraphQL The Devil's API",
+  "title": "GraphQL: The Devil\u2019s API",
   "videos": [
     {
       "length": 2242,

--- a/pycon-us-2022/videos/talk-sam-scott-why-authorization-is-hard.json
+++ b/pycon-us-2022/videos/talk-sam-scott-why-authorization-is-hard.json
@@ -21,7 +21,7 @@
     "talk"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/2BN96ON48U8/maxresdefault.jpg",
-  "title": "Talk - Sam Scott: Why Authorization is Hard",
+  "title": "Why Authorization is Hard",
   "videos": [
     {
       "length": 1719,

--- a/pycon-us-2022/videos/talk-sam-scott-why-authorization-is-hard.json
+++ b/pycon-us-2022/videos/talk-sam-scott-why-authorization-is-hard.json
@@ -1,0 +1,32 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Every team implements authorization in their app to control which users can do what. You'd think by now we'd have a standard set of best practices for how to build it. And yet, we don't! Especially in the Python ecosystem. Why is authorization so hard?\n\nAuthorization is made up of three building blocks, each of which presents its own challenges:\n\n1. Enforcing authorization is hard because it needs to happen in so many places. Controllers, database mappers, routers, and user interfaces all need to enforce authorization. As a result, there are limited off-the-shelf approaches that work in all cases.\n\n2. Decision architecture is hard because you want to separate authorization from the application, but a lot of authorization data is application data too. A monolith can check its own database when it needs to make a decision, but what happens if you want to consolidate authorization into a separate service? Many off-the-shelf solutions focus on the separation \u2013 coordinating it and keeping everything in sync is challenging too.\n\n3. Modeling authorization is hard too. It's easy to whip up the first use case \u2014 adding a roles table to your database works for a while. But it's hard to start simple and grow into your complexity as you need it. And it's hard to make something powerful that's simple to get started with. The options available typically err on one end of the spectrum or the other.\n\nIn this talk, you'll learn the approaches for how to solve each of these areas and the associated tradeoffs.",
+  "duration": 1719,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/11/2022-04-29T22%3A32%3A41.095872/deck-fa3c23.pdf"
+    }
+  ],
+  "speakers": [
+    "Sam Scott"
+  ],
+  "tags": [
+    "talk"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/2BN96ON48U8/maxresdefault.jpg",
+  "title": "Talk - Sam Scott: Why Authorization is Hard",
+  "videos": [
+    {
+      "length": 1719,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=2BN96ON48U8"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-sangarshanan-build-a-database-with-python.json
+++ b/pycon-us-2022/videos/talk-sangarshanan-build-a-database-with-python.json
@@ -17,7 +17,7 @@
     "talk"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/Ay9MNXXURBc/maxresdefault.jpg",
-  "title": "Talk - Sangarshanan: Build-a-Database with Python",
+  "title": "Build-a-Database with Python",
   "videos": [
     {
       "length": 1412,

--- a/pycon-us-2022/videos/talk-sangarshanan-build-a-database-with-python.json
+++ b/pycon-us-2022/videos/talk-sangarshanan-build-a-database-with-python.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "This talk will help unlock the internal workings of a Database by breaking down the abstractions that make it. We will use Python as our weapon of choice to slowly discuss how you would go about building the different components of a database.\n\n1. Talking to your Database: We start by building out an interface and a language that helps us communicate with our database. We will use Prompt toolkit to build a REPL & use a simple SQL-based language with basic regular expressions that can parse it to instruction to execute.\n2. Working with Data: Now that we can communicate with our database using instructions. we start the actual work in building out the Datastore, We initially store all the data in a simple in-memory dictionary and then move to persist this data to disk. We now read the data from the disk to memory every time we query the data and write back the data to the disk but this makes things very slow :( This problem is our entry into the beautiful world of Indexes so by building a very basic Btree index to store references in memory to quickly access only what we require from the data on disk we can actually speed up our access times for basic row access queries from O(N) to O(1) where N is the number of rows in a table\n3. Future: We can now proudly demo our new and polished database that can store data, persist it, and can run queries that are quite fast thanks to our Btree Indexes. We also discuss how this Database can be improved in the future by supporting full ACID Transactions, allowing concurrency, and handling locks\n\nThe best way to understand something is to build it yourself :)",
+  "duration": 1412,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Sangarshanan"
+  ],
+  "tags": [
+    "talk"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/Ay9MNXXURBc/maxresdefault.jpg",
+  "title": "Talk - Sangarshanan: Build-a-Database with Python",
+  "videos": [
+    {
+      "length": 1412,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=Ay9MNXXURBc"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-sebastiaan-zeeff-demystifying-pythons-internals-diving-into-cpython-by-implementing.json
+++ b/pycon-us-2022/videos/talk-sebastiaan-zeeff-demystifying-pythons-internals-diving-into-cpython-by-implementing.json
@@ -21,7 +21,7 @@
     "talk"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/HYKGZunmF50/hqdefault.jpg",
-  "title": "Talk - Sebastiaan Zeeff: Demystifying Python\u2019s Internals: Diving into CPython by implementing...",
+  "title": "Demystifying Python\u2019s Internals: Diving into CPython by implementing a pipe operator",
   "videos": [
     {
       "length": 1826,

--- a/pycon-us-2022/videos/talk-sebastiaan-zeeff-demystifying-pythons-internals-diving-into-cpython-by-implementing.json
+++ b/pycon-us-2022/videos/talk-sebastiaan-zeeff-demystifying-pythons-internals-diving-into-cpython-by-implementing.json
@@ -1,0 +1,32 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Diving into the CPython source code can feel daunting. Whether you want to start contributing or just want to get a better understanding of Python by exploring its source code, it\u2019s often difficult to know where to start or what you\u2019re missing.\n\nIn my talk, I will show you around the CPython source code by implementing a new operator, a pipe operator. While doing so, I will discuss core parts of the internals, such as Python\u2019s grammar, its syntax trees, and the underlying logic that will perform the operation. By the end, you will have a good idea of the moving parts involved in core language features.\n\nI will also take you through the steps necessary to make it all work. I\u2019ll show you how I obtained a copy of the source code, regenerated the parser and token files, and how I compiled my modified version of CPython. I will also write and run tests to help me implement my changes. This should give you a mental framework that helps you while diving into more comprehensive resources, like the excellent Python Developer\u2019s Guide.\n\nMy talk is aimed at everyone who wants to explore CPython\u2019s internals. You don\u2019t have to be an expert in Python, although some affinity with Python helps with understanding the internals. I will also use C to implement some of the operator logic, but knowledge of C is by no means required. In short, if you\u2019re interested in diving into the CPython source code, this talk is for you.",
+  "duration": 1826,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/71/2022-04-28T15%3A55%3A04.181398/demystifying_cpython_internals_HANDOUT.pdf"
+    }
+  ],
+  "speakers": [
+    "Sebastiaan Zeeff"
+  ],
+  "tags": [
+    "talk"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/HYKGZunmF50/hqdefault.jpg",
+  "title": "Talk - Sebastiaan Zeeff: Demystifying Python\u2019s Internals: Diving into CPython by implementing...",
+  "videos": [
+    {
+      "length": 1826,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=HYKGZunmF50"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-tadeh-hakopian-programming-your-way-up-a-skyscraper-python-in-the-built-world.json
+++ b/pycon-us-2022/videos/talk-tadeh-hakopian-programming-your-way-up-a-skyscraper-python-in-the-built-world.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Learn how Architects leverage Python in building projects to enable more design possibilities than ever before. Python is one of the fastest growing scripting languages in the Building design and construction field increasingly being used by professional in the industry. This talk will lead you through how Architects design, plan, edit and execute scripts with Python using different editing tools. Learn about how designers tackle the challenge of putting a building together with the aid of code including; using Python script to edit geometry, create algorithmic design for buildings, sort data lists, write content to software and much more. With Python you can unleash the potential in your projects so come and see what\u2019s possible.",
+  "duration": 1821,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Tadeh Hakopian"
+  ],
+  "tags": [
+    "talk"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/8qEbrxRgDng/hqdefault.jpg",
+  "title": "Talk - Tadeh Hakopian: Programming Your Way up a Skyscraper - Python in the Built World",
+  "videos": [
+    {
+      "length": 1821,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=8qEbrxRgDng"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-tadeh-hakopian-programming-your-way-up-a-skyscraper-python-in-the-built-world.json
+++ b/pycon-us-2022/videos/talk-tadeh-hakopian-programming-your-way-up-a-skyscraper-python-in-the-built-world.json
@@ -17,7 +17,7 @@
     "talk"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/8qEbrxRgDng/hqdefault.jpg",
-  "title": "Talk - Tadeh Hakopian: Programming Your Way up a Skyscraper - Python in the Built World",
+  "title": "Programming Your Way up a Skyscraper - Python in the Built World",
   "videos": [
     {
       "length": 1821,

--- a/pycon-us-2022/videos/talk-tetsuya-jesse-hirata-productionize-research-oriented-code-by-python.json
+++ b/pycon-us-2022/videos/talk-tetsuya-jesse-hirata-productionize-research-oriented-code-by-python.json
@@ -21,7 +21,7 @@
     "talk"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/bJPov74qjb8/maxresdefault.jpg",
-  "title": "Talk - Tetsuya Jesse Hirata: Productionize Research Oriented Code By Python",
+  "title": "Productionize Research Oriented Code By Python",
   "videos": [
     {
       "length": 1690,

--- a/pycon-us-2022/videos/talk-tetsuya-jesse-hirata-productionize-research-oriented-code-by-python.json
+++ b/pycon-us-2022/videos/talk-tetsuya-jesse-hirata-productionize-research-oriented-code-by-python.json
@@ -1,0 +1,32 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Target audiences might be python engineers who is involved with R&D, data science, AI/ML projects, or data oriented projects.\n\n\u3010Introduction\u3011\n\n- Background\n- Definition of Research Oriented Code and Production Code\n- Differences between Research Oriented Code and Production Code\n\n\u3010Main Talk\u3011\n\nFour steps to productionize research oriented code\n\n1. Understand the code through code reading and code documentation\n2. Modularize the code into preparation code, pre/post-process code, calculation code based on the code documents\n3. Refactor the code with test code\n4. Make them products\n\n\u3010Summary\u3011\n\n- Summarize the four steps to productionize research oriented code\n- After making the code products, improve performance and monitor the behaviors of production code",
+  "duration": 1690,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/77/2022-04-27T13%3A38%3A31.337676/pycon_us_2022_with_note.pdf"
+    }
+  ],
+  "speakers": [
+    "Tetsuya Jesse Hirata"
+  ],
+  "tags": [
+    "talk"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/bJPov74qjb8/maxresdefault.jpg",
+  "title": "Talk - Tetsuya Jesse Hirata: Productionize Research Oriented Code By Python",
+  "videos": [
+    {
+      "length": 1690,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=bJPov74qjb8"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-trey-hunner-python-oddities-explained.json
+++ b/pycon-us-2022/videos/talk-trey-hunner-python-oddities-explained.json
@@ -17,7 +17,7 @@
     "talk"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/nWC73Llo170/hqdefault.jpg",
-  "title": "Talk - Trey Hunner: Python Oddities Explained",
+  "title": "Python Oddities Explained",
   "videos": [
     {
       "length": 1544,

--- a/pycon-us-2022/videos/talk-trey-hunner-python-oddities-explained.json
+++ b/pycon-us-2022/videos/talk-trey-hunner-python-oddities-explained.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "A number of Python features often seem counter-intuitive at first glance, especially when moving from another programming language to Python. Often what at first seems like a bug, will later reveal itself to be a misunderstood feature.\n\nDuring this talk we'll look at a number of Python's unique features and quirks and attempt to re-shape our mental models of Python to better match reality. By the end of this talk you'll have a deeper understanding of Python's rules behind objects, scope, and variables.\n\nWarning: this talk will include many Python head-scratchers so show up prepared to think on your feet!",
+  "duration": 1544,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Trey Hunner"
+  ],
+  "tags": [
+    "talk"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/nWC73Llo170/hqdefault.jpg",
+  "title": "Talk - Trey Hunner: Python Oddities Explained",
+  "videos": [
+    {
+      "length": 1544,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=nWC73Llo170"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-vic-kumar-writing-functional-code-in-python.json
+++ b/pycon-us-2022/videos/talk-vic-kumar-writing-functional-code-in-python.json
@@ -17,7 +17,7 @@
     "talk"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/x7sQVLO3JJA/maxresdefault.jpg",
-  "title": "Talk - Vic Kumar: Writing Functional Code in Python",
+  "title": "Writing Functional Code in Python",
   "videos": [
     {
       "length": 1756,

--- a/pycon-us-2022/videos/talk-vic-kumar-writing-functional-code-in-python.json
+++ b/pycon-us-2022/videos/talk-vic-kumar-writing-functional-code-in-python.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "In this talk, we'll define exactly what functional programming is and how it helps us.  We'll explore the main concepts from functional programming and see how we can apply them to our Python code going over some concrete examples.",
+  "duration": 1756,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Vic Kumar"
+  ],
+  "tags": [
+    "talk"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/x7sQVLO3JJA/maxresdefault.jpg",
+  "title": "Talk - Vic Kumar: Writing Functional Code in Python",
+  "videos": [
+    {
+      "length": 1756,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=x7sQVLO3JJA"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-william-morrell-professionally-coding-with-others.json
+++ b/pycon-us-2022/videos/talk-william-morrell-professionally-coding-with-others.json
@@ -21,7 +21,7 @@
     "talk"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/IcvxW-EhEV0/hqdefault.jpg",
-  "title": "Talk - William Morrell: (Professionally) Coding with Others",
+  "title": "(Professionally) Coding with Others",
   "videos": [
     {
       "length": 1531,

--- a/pycon-us-2022/videos/talk-william-morrell-professionally-coding-with-others.json
+++ b/pycon-us-2022/videos/talk-william-morrell-professionally-coding-with-others.json
@@ -1,0 +1,32 @@
+{
+  "copyright_text": "CC BY",
+  "description": "A mix of tools and practices to incorporate for facilitating collaboration between developers. As a nice side-effect, these also let past-you help future-you work on entirely solo projects. Topics include:\n\n- Documentation, specifically calling out a README and contributor guidelines, and site generators \u00e0 la Sphinx or MkDocs;\n- Version control / git, collecting changes in logical commits, writing good commit and pull request messages;\n- Auto-lint and formatting: pre-commit, black, isort, flake8;\n- Dependency management: pyenv, pipenv/poetry, Docker;",
+  "duration": 1531,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/103/2022-04-11T02%3A51%3A35.659719/pycon_export.pdf"
+    }
+  ],
+  "speakers": [
+    "William Morrell"
+  ],
+  "tags": [
+    "talk"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/IcvxW-EhEV0/hqdefault.jpg",
+  "title": "Talk - William Morrell: (Professionally) Coding with Others",
+  "videos": [
+    {
+      "length": 1531,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=IcvxW-EhEV0"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talk-zachary-sarah-corleissen-localize-your-open-source-documentation-a-kubernetes-case-study.json
+++ b/pycon-us-2022/videos/talk-zachary-sarah-corleissen-localize-your-open-source-documentation-a-kubernetes-case-study.json
@@ -17,7 +17,7 @@
     "talk"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/0k9UkMrMBYM/maxresdefault.jpg",
-  "title": "Talk - Zachary Sarah Corleissen: Localize your open source documentation: a Kubernetes case study",
+  "title": "Localize your open source documentation: a Kubernetes case study",
   "videos": [
     {
       "length": 1571,

--- a/pycon-us-2022/videos/talk-zachary-sarah-corleissen-localize-your-open-source-documentation-a-kubernetes-case-study.json
+++ b/pycon-us-2022/videos/talk-zachary-sarah-corleissen-localize-your-open-source-documentation-a-kubernetes-case-study.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "NOTE: video begins at ~3:45\nThis talk covers how Kubernetes docs were able to scale from zero to eleven localizations within six months in 2018. It covers what docs maintainers learned, mistakes to avoid, and how you can start localizing your own open source project.\n\nGreat documentation drives developer adoption...but documentation is only great if it's accessible. One piece of accessibility is localization: the ability for developers to access information in their native or primary language.\n\nThis talk covers the specifics of scalable localization that other projects can adopt, based on the Kubernetes documentation model: tooling, workflows, standards for minimum viable documentation, and community conduct.\n\nThis talk also covers some avoidable mistakes to save your maintainers time and stress, as well as the ongoing greater-than-additive benefits that localization can bring.\n\nThis talk concludes with specific recommendations for other projects to start their own localizations.",
+  "duration": 1571,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Zachary Sarah Corleissen"
+  ],
+  "tags": [
+    "talk"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/0k9UkMrMBYM/maxresdefault.jpg",
+  "title": "Talk - Zachary Sarah Corleissen: Localize your open source documentation: a Kubernetes case study",
+  "videos": [
+    {
+      "length": 1571,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=0k9UkMrMBYM"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/talks-fred-phillips-hooking-into-the-import-system.json
+++ b/pycon-us-2022/videos/talks-fred-phillips-hooking-into-the-import-system.json
@@ -17,7 +17,7 @@
     "talk"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/ziC_DlabFto/hqdefault.jpg",
-  "title": "Talks - Fred Phillips: Hooking into the import system",
+  "title": "Hooking into the import system",
   "videos": [
     {
       "length": 1399,

--- a/pycon-us-2022/videos/talks-fred-phillips-hooking-into-the-import-system.json
+++ b/pycon-us-2022/videos/talks-fred-phillips-hooking-into-the-import-system.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Import hooks and the import system in general is an under-used and under-documented resource within Python. This talk will introduce the audience to the import system, how it works, and how it can be adapted for their needs. We will build a simple import hook that can inspect what is being imported, and go on to demonstrate how we can use the import system to load Python modules from a database and how to reload files on disk immediately as they are changed.",
+  "duration": 1399,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Fred Phillips"
+  ],
+  "tags": [
+    "talk"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/ziC_DlabFto/hqdefault.jpg",
+  "title": "Talks - Fred Phillips: Hooking into the import system",
+  "videos": [
+    {
+      "length": 1399,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=ziC_DlabFto"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/tutorial-ariel-ortiz-a-pythonista-s-introductory-guide-to-web-assembly.json
+++ b/pycon-us-2022/videos/tutorial-ariel-ortiz-a-pythonista-s-introductory-guide-to-web-assembly.json
@@ -1,0 +1,32 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Wasm is a binary code format specification first released in 2017. This technology can be implemented in web browsers or standalone applications in a secure, open, portable, and efficient fashion. More precisely, Wasm is an intermediate language for a stack-based virtual machine that uses a just-in-time (JIT) compiler to produce native machine code. Although Wasm was primarily designed as a compilation target for languages such as C/C++ or Rust, it can be integrated with Python in interesting ways. And that\u2019s what we\u2019ll be focusing on during this tutorial. Some experience with JavaScript and web development might come in handy but is not strictly required. At the end, we\u2019ll show how to develop a tiny compiler that has Wasm as it\u2019s compilation target.",
+  "duration": 10040,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/53/2022-05-05T23%3A36%3A12.746488/webassembly_tutorial.pdf"
+    }
+  ],
+  "speakers": [
+    "Ariel Ortiz"
+  ],
+  "tags": [
+    "tutorial"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/NOAZuGFhfV0/hqdefault.jpg",
+  "title": "Tutorial - Ariel Ortiz: A Pythonista's Introductory Guide to Web Assembly",
+  "videos": [
+    {
+      "length": 10040,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=NOAZuGFhfV0"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/tutorial-ariel-ortiz-a-pythonista-s-introductory-guide-to-web-assembly.json
+++ b/pycon-us-2022/videos/tutorial-ariel-ortiz-a-pythonista-s-introductory-guide-to-web-assembly.json
@@ -21,7 +21,7 @@
     "tutorial"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/NOAZuGFhfV0/hqdefault.jpg",
-  "title": "Tutorial - Ariel Ortiz: A Pythonista's Introductory Guide to Web Assembly",
+  "title": "A Pythonista's Introductory Guide to Web Assembly",
   "videos": [
     {
       "length": 10040,

--- a/pycon-us-2022/videos/tutorial-cheuk-ting-ho-knowledge-graph-data-modelling-with-terminusdb.json
+++ b/pycon-us-2022/videos/tutorial-cheuk-ting-ho-knowledge-graph-data-modelling-with-terminusdb.json
@@ -21,7 +21,7 @@
     "tutorial"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/nHTm-2YvSp8/hqdefault.jpg",
-  "title": "Tutorial - Cheuk Ting Ho: Knowledge graph data modelling with TerminusDB",
+  "title": "Knowledge graph data modelling with TerminusDB",
   "videos": [
     {
       "length": 8814,

--- a/pycon-us-2022/videos/tutorial-cheuk-ting-ho-knowledge-graph-data-modelling-with-terminusdb.json
+++ b/pycon-us-2022/videos/tutorial-cheuk-ting-ho-knowledge-graph-data-modelling-with-terminusdb.json
@@ -1,0 +1,32 @@
+{
+  "copyright_text": "CC BY",
+  "description": "FOR WHOM IS YOUR WORKSHOP\n\nData scientists, engineers and researchers who have no prior experience in knowledge graph data modelling. In this workshop, we will start from the fundamentals - learning how to think in terms of triples to describe relations of different data objects. If your work involves data analysis, data management, data collaboration or anything data-related, this is a workshop for you to have a brand new insight into how data should be represented and stored.\n\nSHORT FORMAT OF YOUR WORKSHOP\n\nOverview-10 min, Lecture - 60 mins, Breaks- 20 minutes, Hands-on training - 80 mins, Closing - 10 mins\n\nWHAT ATTENDEES WILL LEARN\n\nBy the end of the workshop, you will be able to think like a knowledge graph expert and construct a proper schema to store your data in a knowledge graph format. You will acquire the skills that you need to build knowledge graphs in TerminusDB - an open-source graph database that enables revisional control and collaborations.\n\nCOURSE BENEFITS\n\nYou will have learnt a new skill set that may assist you in your project in data science or research. You will have a new tool that you can better model your data and collaborate with others. Also, you gain all the prerequisites to use WOQL - a query language for knowledge graphs and the TerminusDB Python client to manage, manipulate and visualize data in your knowledge graph.",
+  "duration": 8814,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/50/2022-04-26T08%3A51%3A50.741435/Data_Modelling_Workshop.pdf"
+    }
+  ],
+  "speakers": [
+    "Cheuk Ting Ho"
+  ],
+  "tags": [
+    "tutorial"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/nHTm-2YvSp8/hqdefault.jpg",
+  "title": "Tutorial - Cheuk Ting Ho: Knowledge graph data modelling with TerminusDB",
+  "videos": [
+    {
+      "length": 8814,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=nHTm-2YvSp8"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/tutorial-eric-ma-network-analysis-made-simple.json
+++ b/pycon-us-2022/videos/tutorial-eric-ma-network-analysis-made-simple.json
@@ -17,7 +17,7 @@
     "tutorial"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/5vU5nRjaac4/hqdefault.jpg",
-  "title": "Tutorial - Eric Ma: Network Analysis Made Simple",
+  "title": "Network Analysis Made Simple",
   "videos": [
     {
       "length": 10037,

--- a/pycon-us-2022/videos/tutorial-eric-ma-network-analysis-made-simple.json
+++ b/pycon-us-2022/videos/tutorial-eric-ma-network-analysis-made-simple.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Have you ever wondered about how data scientists at Facebook and LinkedIn make friend recommendations? Or how epidemiologists track down patient zero in an outbreak? If so, then this tutorial is for you. In this tutorial, we will use a variety of datasets to help you understand the fundamentals of network thinking, with a particular focus on constructing, summarizing, visualizing, and using complex networks to solve problems.",
+  "duration": 10037,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Eric Ma"
+  ],
+  "tags": [
+    "tutorial"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/5vU5nRjaac4/hqdefault.jpg",
+  "title": "Tutorial - Eric Ma: Network Analysis Made Simple",
+  "videos": [
+    {
+      "length": 10037,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=5vU5nRjaac4"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/tutorial-francesco-bruni-getting-started-with-object-oriented-programming-through-signal.json
+++ b/pycon-us-2022/videos/tutorial-francesco-bruni-getting-started-with-object-oriented-programming-through-signal.json
@@ -21,7 +21,7 @@
     "tutorial"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/0861fV0WasQ/hqdefault.jpg",
-  "title": "Tutorial - Francesco Bruni: Getting started with Object-Oriented Programming through Signal...",
+  "title": "Getting started with Object-Oriented Programming through Signal Processing",
   "videos": [
     {
       "length": 11611,

--- a/pycon-us-2022/videos/tutorial-francesco-bruni-getting-started-with-object-oriented-programming-through-signal.json
+++ b/pycon-us-2022/videos/tutorial-francesco-bruni-getting-started-with-object-oriented-programming-through-signal.json
@@ -1,0 +1,32 @@
+{
+  "copyright_text": "CC BY",
+  "description": "In this tutorial OOP foundations will be explored fitting signals and waves into objects.\n\nWe will follow a top-down methodology, by modelling signals from scratch, creating fatty objects, and then tweaking their representation introducing inheritance and delegation. We will talk about Python magic methods to implement processing operations. We will eventually see how to implement the Iterator Design Pattern.\n\nTrough the session, we will keep a special eye on code explicitness and simplicity, highlighting pros and cons of every implementation.\n\nA laptop with Python installed is the sole requirement.\nNeverthless, it could be handful having a Jupyter notebook instance running to visualize and listen to signals easily. In this case only numpy and matplotlib should be already installed.",
+  "duration": 11611,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/28/2022-04-26T16%3A18%3A44.431273/pyconus22_complete.pdf"
+    }
+  ],
+  "speakers": [
+    "Francesco Bruni"
+  ],
+  "tags": [
+    "tutorial"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/0861fV0WasQ/hqdefault.jpg",
+  "title": "Tutorial - Francesco Bruni: Getting started with Object-Oriented Programming through Signal...",
+  "videos": [
+    {
+      "length": 11611,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=0861fV0WasQ"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/tutorial-jacob-deppen-documenting-your-code-from-docstrings-to-automated-builds.json
+++ b/pycon-us-2022/videos/tutorial-jacob-deppen-documenting-your-code-from-docstrings-to-automated-builds.json
@@ -17,7 +17,7 @@
     "tutorial"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/liBdNwU34e0/hqdefault.jpg",
-  "title": "Tutorial - Jacob Deppen: Documenting your code from docstrings to automated builds",
+  "title": "Documenting your code from docstrings to automated builds",
   "videos": [
     {
       "length": 10743,

--- a/pycon-us-2022/videos/tutorial-jacob-deppen-documenting-your-code-from-docstrings-to-automated-builds.json
+++ b/pycon-us-2022/videos/tutorial-jacob-deppen-documenting-your-code-from-docstrings-to-automated-builds.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "IF IT ISN'T DOCUMENTED, IT DOESN'T EXIST.\n\nDocumentation can make or break a project. Getting it right takes effort, but that effort doesn't have to be painful. In this tutorial, we will take a multi-stage approach to documentation, starting with the fundamentals, adding complexity and style, then finishing with automated publishing to the web. We will practice a maintainer-friendly workflow that smooths out some of the rough edges of creating documentation.\n\nIt is never too early or too late to pick up good documentation techniques and tools. As such, this tutorial will have elements that are relevant to brand new Pythonistas (What does a good docstring look like? What is a type hint?) as well as long-time practitioners (How can I make my docs easier to maintain? Where can I host docs? How can I test examples in my docstrings?).\n\nWe will cover code comments, docstrings, and type annotations as ways to add documentation within your code. Next, we will add a user interface and documentation prose layer with JupyterBook, Jupyter Notebooks, and Markdown. After that, we will use Sphinx to build API documentation. Finally, we will automate the build and publish steps with GitHub Actions and GitHub Pages.",
+  "duration": 10743,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Jacob Deppen"
+  ],
+  "tags": [
+    "tutorial"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/liBdNwU34e0/hqdefault.jpg",
+  "title": "Tutorial - Jacob Deppen: Documenting your code from docstrings to automated builds",
+  "videos": [
+    {
+      "length": 10743,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=liBdNwU34e0"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/tutorial-jules-s-damji-distributed-python-with-ray-hands-on-with-the-ray-core-apis.json
+++ b/pycon-us-2022/videos/tutorial-jules-s-damji-distributed-python-with-ray-hands-on-with-the-ray-core-apis.json
@@ -21,7 +21,7 @@
     "tutorial"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/zQExptoTXzs/maxresdefault.jpg",
-  "title": "Tutorial - Jules S. Damji: Distributed Python with Ray: Hands-on with the Ray Core APIs",
+  "title": "Distributed Python with Ray: Hands-on with the Ray Core APIs",
   "videos": [
     {
       "length": 10249,

--- a/pycon-us-2022/videos/tutorial-jules-s-damji-distributed-python-with-ray-hands-on-with-the-ray-core-apis.json
+++ b/pycon-us-2022/videos/tutorial-jules-s-damji-distributed-python-with-ray-hands-on-with-the-ray-core-apis.json
@@ -1,0 +1,32 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Please note: Audio and speaker video do not start until 01:28:26. Our apologies for this. \n\nThis is an introductory and hands-on guided tutorial of Ray Core. Ray provides powerful yet easy-to-use design patterns for implementing distributed systems in Python. This tutorial includes a brief talk to provide an overview of concepts, why one might use Ray for distributing Python and Machine Learning workloads, and a brief discussion on Ray\u2019s Ecosystem.\n\nPrimarily, the tutorial will focus on Ray Core APIs to write remote functions, actors, and understand Ray\u2019s basic design patterns for writing distributed Python applications.",
+  "duration": 10249,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/164/2022-04-25T16%3A51%3A23.026629/pyconsus_slides.pdf"
+    }
+  ],
+  "speakers": [
+    "Jules S. Damji"
+  ],
+  "tags": [
+    "tutorial"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/zQExptoTXzs/maxresdefault.jpg",
+  "title": "Tutorial - Jules S. Damji: Distributed Python with Ray: Hands-on with the Ray Core APIs",
+  "videos": [
+    {
+      "length": 10249,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=zQExptoTXzs"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/tutorial-mario-munoz-goodbye-hello-world-hello-functional-fastapi-web-app.json
+++ b/pycon-us-2022/videos/tutorial-mario-munoz-goodbye-hello-world-hello-functional-fastapi-web-app.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Building a web application with Python is super easy. With just a few lines of code, you can get a simple, working app running directly on your computer's browser.\n\nAwesome! But then what?\n\nThis tutorial focuses on that awkward transition from beginner to intermediate\u2014when you want a project to be less of a sketchpad and more of an actual, useful tool.\n\nWe will learn tactics on how to find and use resources when devising a plan for your web application, as well as hands-on learning for tackling common (and necessary) aspects of building your app, such as configuration, app structure, and database modeling.\n\nFor the training, you will be following along as we build the foundation of a fully-functional web application, and will leave with the ability to further refine it for real-world scenarios.",
+  "duration": 10949,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Mario Munoz"
+  ],
+  "tags": [
+    "tutorial"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/gDYrFsMaxIw/hqdefault.jpg",
+  "title": "Tutorial - Mario Munoz: Goodbye, \"Hello, World.\" Hello, Functional FastAPI Web App!",
+  "videos": [
+    {
+      "length": 10949,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=gDYrFsMaxIw"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/tutorial-mario-munoz-goodbye-hello-world-hello-functional-fastapi-web-app.json
+++ b/pycon-us-2022/videos/tutorial-mario-munoz-goodbye-hello-world-hello-functional-fastapi-web-app.json
@@ -17,7 +17,7 @@
     "tutorial"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/gDYrFsMaxIw/hqdefault.jpg",
-  "title": "Tutorial - Mario Munoz: Goodbye, \"Hello, World.\" Hello, Functional FastAPI Web App!",
+  "title": "Goodbye, \"Hello, World.\" Hello, Functional FastAPI Web App!",
   "videos": [
     {
       "length": 10949,

--- a/pycon-us-2022/videos/tutorial-pandy-knight-awesome-modern-web-testing-with-playwright.json
+++ b/pycon-us-2022/videos/tutorial-pandy-knight-awesome-modern-web-testing-with-playwright.json
@@ -1,0 +1,28 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Everybody gets frustrated when web apps are broken, but testing them thoroughly doesn't need to be a chore. Playwright, a new open-source browser automation tool from Microsoft, makes testing web apps fun! Playwright outperforms other tools like Selenium WebDriver with a slew of nifty features like automatic waiting, mobile emulation, and network interception. Plus, with isolated browser contexts, Playwright tests can set up much faster than traditional Web UI tests.\n\nIn this tutorial, we will build a Python test automation project from the ground up. We will automate web search engine tests together step-by-step using Playwright for interactions and pytest for execution.\n\nSpecifically, we will cover:\n\n1. How to install and configure Playwright\n2. How to integrate Playwright with pytest, Python\u2019s leading test framework\n3. How to perform interactions through page objects\n4. How to conveniently run different browsers, capture videos, and run tests in parallel\n\nBy the end of this tutorial, you'll be empowered to test modern web apps with modern web test tools. You'll also have an example project to be the foundation for your future tests. You can use Playwright to test Django apps, Flask apps, or any other kinds of apps!",
+  "duration": 11711,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Pandy Knight"
+  ],
+  "tags": [
+    "tutorial"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/JEll871aplI/hqdefault.jpg",
+  "title": "Tutorial - Pandy Knight: Awesome Modern Web Testing with Playwright",
+  "videos": [
+    {
+      "length": 11711,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=JEll871aplI"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/tutorial-pandy-knight-awesome-modern-web-testing-with-playwright.json
+++ b/pycon-us-2022/videos/tutorial-pandy-knight-awesome-modern-web-testing-with-playwright.json
@@ -17,7 +17,7 @@
     "tutorial"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/JEll871aplI/hqdefault.jpg",
-  "title": "Tutorial - Pandy Knight: Awesome Modern Web Testing with Playwright",
+  "title": "Awesome Modern Web Testing with Playwright",
   "videos": [
     {
       "length": 11711,

--- a/pycon-us-2022/videos/tutorial-pradeep-kumar-srinivasan-jia-chen-shannon-zhu-python-types-for-fun-and-profit.json
+++ b/pycon-us-2022/videos/tutorial-pradeep-kumar-srinivasan-jia-chen-shannon-zhu-python-types-for-fun-and-profit.json
@@ -1,0 +1,30 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Many Python developers now use type annotations to catch and fix bugs early in the coding process. This tutorial will introduce you to type annotations in Python. We\u2019ll cover basic ideas about how types work in a dynamic language like Python, and where explicit annotations can provide value. We\u2019ll then explore features of the type system in more depth, and demonstrate how they can be used to precisely yet flexibly express a huge range of programming patterns.\n\nThroughout the tutorial, you will have the chance to get your hands dirty by learning how to add types to small code snippets as well as to an example GitHub project, and run a type checker to see errors as you code. You\u2019ll get to practice and play around with each concept as we discuss it, and walk away with concrete experience adding types to and catching bugs in real code.\n\nA laptop with Python installed is required along with internet access.",
+  "duration": 13078,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Pradeep Kumar Srinivasan",
+    "Jia Chen",
+    "Shannon Zhu"
+  ],
+  "tags": [
+    "tutorial"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/kD_fCqBNTvI/maxresdefault.jpg",
+  "title": "Tutorial - Pradeep Kumar Srinivasan, Jia Chen, Shannon Zhu: Python Types for Fun and Profit",
+  "videos": [
+    {
+      "length": 13078,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=kD_fCqBNTvI"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/tutorial-pradeep-kumar-srinivasan-jia-chen-shannon-zhu-python-types-for-fun-and-profit.json
+++ b/pycon-us-2022/videos/tutorial-pradeep-kumar-srinivasan-jia-chen-shannon-zhu-python-types-for-fun-and-profit.json
@@ -19,7 +19,7 @@
     "tutorial"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/kD_fCqBNTvI/maxresdefault.jpg",
-  "title": "Tutorial - Pradeep Kumar Srinivasan, Jia Chen, Shannon Zhu: Python Types for Fun and Profit",
+  "title": "Python Types for Fun and Profit",
   "videos": [
     {
       "length": 13078,

--- a/pycon-us-2022/videos/tutorial-zac-hatfield-dodds-introduction-to-property-based-testing.json
+++ b/pycon-us-2022/videos/tutorial-zac-hatfield-dodds-introduction-to-property-based-testing.json
@@ -1,0 +1,32 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Has testing got you down? Ever spent a day writing tests, only to discover that you missed a bug because of some edge case you didn\u2019t know about? Does it ever feel like writing tests is just a formality - that you already know your test cases will pass?\n\nProperty-based testing might be just what you need!\n\nAfter this introduction to property-based testing, you\u2019ll be comfortable with Hypothesis, a friendly but powerful property-based testing library. You\u2019ll also known how to check and enforce robust properties in your code, and will have hands-on experience finding real bugs.\n\nWhere traditional example-based tests require you to write out each exact scenario to check - for example, assert divide(3, 4) == 0.75 - property-based tests are generalised and assisted. You describe what kinds of inputs are allowed, write a test that should pass for any of them, and Hypothesis does the rest!\n\n    from hypothesis import given, strategies as st\n\n    @given(a=st.integers(), b=st.integers())\n    def test_divide(a, b):\n    result = a / b\n    assert a == b * result\n\nThere\u2019s the obvious ZeroDivisionError, fixable with b = st.integers().filter(lambda b: b != 0), but there\u2019s another bug lurking. Can you see it? Hypothesis can!\n\nAUDIENCE\n\nThis tutorial is for anybody who regularly writes tests in Python, and would like an easier and more effective way to do so. We assume that you are comfortable with traditional unit tests - reading, running, and writing; as well as familar with ideas like assertions. Most attendees will have heard \"given, when, then\" and \"arrange, act, assert\". You may or may not have heard of pre- and post-conditions - we will explain what \"property-based\" means without reference to Haskell or anything algebraic.",
+  "duration": 5059,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    },
+    {
+      "label": "Slides",
+      "url": "https://pycon-assets.s3.amazonaws.com/2022/media/presentation_slides/177/2022-04-26T04%3A34%3A57.242477/PBT-intro-PyCon-2022.pdf"
+    }
+  ],
+  "speakers": [
+    "Zac Hatfield-Dodds"
+  ],
+  "tags": [
+    "tutorial"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/6Hdn8hBw_Gs/hqdefault.jpg",
+  "title": "Tutorial - Zac Hatfield-Dodds: Introduction to Property Based Testing",
+  "videos": [
+    {
+      "length": 5059,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=6Hdn8hBw_Gs"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/tutorial-zac-hatfield-dodds-introduction-to-property-based-testing.json
+++ b/pycon-us-2022/videos/tutorial-zac-hatfield-dodds-introduction-to-property-based-testing.json
@@ -21,7 +21,7 @@
     "tutorial"
   ],
   "thumbnail_url": "https://i.ytimg.com/vi/6Hdn8hBw_Gs/hqdefault.jpg",
-  "title": "Tutorial - Zac Hatfield-Dodds: Introduction to Property Based Testing",
+  "title": "Introduction to Property Based Testing",
   "videos": [
     {
       "length": 5059,

--- a/pycon-us-2022/videos/typing-summit-at-pycon-us-2022.json
+++ b/pycon-us-2022/videos/typing-summit-at-pycon-us-2022.json
@@ -1,0 +1,36 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Schedule of presentations:\n\n0:00 - \u201cNew typing features in Python 3.10 and 3.11\u201d, David Foster\n\n17:51 - \u201cTyping of Tensor Shapes and Type Arithmetic\u201d, Alfonso Casta\u00f1o\n\n39:15 - \u201cToo small for a PEP: minor new typing features in Python 3.11\u201d, Jelle Zijlstra\n\n1:00:43 - Extending PEP 647: User-Defined Type Guards\u201d, Rebecca Chen\n\n1:19:07 - \u201cThe future of TypedDict\" and \"Runtime uses for type annotations: A survey of tools\u201d, David Foster\n\n1:50:30 - \u201cRuntime Annotations: PEP 563 & 649 Overview\u201d, Carl Meyer\n\n2:21:05 - \u201cBeyond Subtyping\u201d, Kevin Millikin\n\n2:50:44 - \u201cPanel: Typing-sig and Python Core Dev\u201d, Guido van Rossum, Pablo Galindo Salgado, Thomas Wouters, Jelle Zijlstra, Pradeep Kumar Srinivasan, Matthew Rahtz",
+  "duration": 11050,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "David Foster",
+    "Alfonso Casta\u00f1o",
+    "Jelle Zijlstra",
+    "Rebecca Chen",
+    "Carl Meyer",
+    "Kevin Millikin",
+    "Guido van Rossum",
+    "Pablo Galindo Salgado",
+    "Thomas Wouters",
+    "Pradeep Kumar Srinivasan",
+    "Matthew Rahtz"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/BNTkWQfqP_c/hqdefault.jpg",
+  "title": "Typing Summit - at PyCon US 2022",
+  "videos": [
+    {
+      "length": 11050,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=BNTkWQfqP_c"
+    }
+  ]
+}

--- a/pycon-us-2022/videos/typing-summit-at-pycon-us-2022.json
+++ b/pycon-us-2022/videos/typing-summit-at-pycon-us-2022.json
@@ -25,7 +25,7 @@
   ],
   "tags": [],
   "thumbnail_url": "https://i.ytimg.com/vi/BNTkWQfqP_c/hqdefault.jpg",
-  "title": "Typing Summit - at PyCon US 2022",
+  "title": "Typing Summit",
   "videos": [
     {
       "length": 11050,

--- a/pycon-us-2022/videos/welcome-emily-morehouse.json
+++ b/pycon-us-2022/videos/welcome-emily-morehouse.json
@@ -1,0 +1,26 @@
+{
+  "copyright_text": "CC BY",
+  "description": "Welcome to PyCon US 2022\n\nNote: Video begins at 1:50",
+  "duration": 1255,
+  "language": "eng",
+  "recorded": "2022-04-27",
+  "related_urls": [
+    {
+      "label": "Conference schedule",
+      "url": "https://us.pycon.org/2022/schedule/"
+    }
+  ],
+  "speakers": [
+    "Emily Morehouse"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/nWnIRYQrVtk/hqdefault.jpg",
+  "title": "Welcome - Emily Morehouse",
+  "videos": [
+    {
+      "length": 1255,
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=nWnIRYQrVtk"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the PyCon US 2022 videos to PyVideo. All videos are pulled from the official YouTube playlist.