### PR TITLE
Disallow additional properties on category schema

### DIFF
--- a/.schemas/category.json
+++ b/.schemas/category.json
@@ -18,6 +18,7 @@
   "required":[
     "title"
   ],
+  "additionalProperties": false,
   "title":"Video",
   "type":"object"
 }


### PR DESCRIPTION
The intent of this change is to update the schema without any test failures. This means that other changes that affect the data should happen independently from the pull request associated with this commit, and it should be kept up to date and merged once the schema tests pass. To contribute to this change, open PRs that would correct any data that does not conform to the JSON schema. Discussion regarding other schema updates should happen in the associated issue at #1171.

Resolves #1171.