### PR TITLE
 Disallow additional properties on video schema

### DIFF
--- a/.schemas/video.json
+++ b/.schemas/video.json
@@ -144,6 +144,7 @@
     "title",
     "videos"
   ],
+  "additionalProperties": false,
   "title":"Video",
   "type":"object"
 }


### PR DESCRIPTION
The intent of this change is to update the schema without any test failures. This means that other changes that affect the data should happen independently from the pull request associated with this commit, and it should be kept up to date and merged once the schema tests pass. To contribute to this change, open PRs that would correct any data that does not conform to the JSON schema. Discussion regarding other schema updates should happen in the associated issue at #1173.

Resolves #1173.