### PR TITLE
Added Djangocon 2021 secondary track

### DIFF
--- a/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-cleanroom-software-engineering-with-django-francisco-j-lopez-lira-hinojo.json
+++ b/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-cleanroom-software-engineering-with-django-francisco-j-lopez-lira-hinojo.json
@@ -1,0 +1,28 @@
+{
+  "description": "Cleanroom software engineering process is a software development process developed at IBM intended to produce software with a certifiable level of reliability. A principal objective of the Cleanroom process is development of software that exhibits zero failures in use. In this workshop we will review how to implement it in a project with the help of Django.\n\nThe Software Engineering Institute defines the Cleanroom software engineering as \"a theory-based team-oriented process for development and certification of high-reliability software systems under statistical quality control. A principal objective of the Cleanroom process is development of software that exhibits zero failures in use. The Cleanroom name is borrowed from hardware Cleanrooms, with their emphasis on rigorous engineering discipline and focus on defect prevention rather than defect removal. Cleanroom combines mathematically based methods of software specification, design, and correctness verification with statistical, usage-based testing to certify software fitness for use. Cleanroom projects have reported substantial gains in quality and productivity. \"\n\nThis method was widely adopted in the 90's by organizations like IBM, Ericsson or the US Army with up to 20x gains in quality and 4.6x gains in productivity. It can be used for current technology projects, but it needs the help of tools like Django for implementing it in an organization.\n\nIn this workshop we will learn about this method and then we will do a practical exercise, first with basic tools and then using Django.",
+  "duration": 3458,
+  "language": "eng",
+  "recorded": "2021-06-04",
+  "related_urls": [
+    {
+      "label": "Talk announcement",
+      "url": "https://2021.djangocon.eu/cfp/talk/SXFXBF/index.html"
+    }
+  ],
+  "speakers": [
+    "Francisco J. López-Lira Hinojo"
+  ],
+  "tags": [
+    "Django",
+    "DjangoConEU",
+    "djangoconeu2021"
+  ],
+  "thumbnail_url": "https://img.youtube.com/vi/kkeL9Uha0es/0.jpg",
+  "title": "Cleanroom Software Engineering with Django",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=kkeL9Uha0es"
+    }
+  ]
+}

--- a/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-deploying-a-django-virtual-event-platform-using-containers-and-terraform-calvin-hendryx-parker.json
+++ b/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-deploying-a-django-virtual-event-platform-using-containers-and-terraform-calvin-hendryx-parker.json
@@ -1,0 +1,28 @@
+{
+  "description": "\n\nLearn to leverage cloud native tools and launch a scalable Python and Django application into the Cloud with Fargate. We’ll dive in with how to getting up and running fast, but leaving the overhead of managing virtual machines and Kubernetes behind. Create and store the application Docker images in a container repository and without touching the AWS console we can create fully Infrastructure as Code automated deployments via CodePipeline into Fargate containers and S3 buckets. Deliver the React application via CloudFront and S3 for full global scalability. Leave the legacy deployments behind and forge bravely into the new world of Cloud Native applications.\n\n    Intro to Cloud Native deployment — 10%\n        Hitchhikers Guide to Cloud Native vocabulary\n    Laying the groundwork for going Cloud Native — 10%\n        Containerizing your app\n        Preparing your image for production\n    Building the pipeline — 20%\n        Sketching out your infrastructure\n        Moving to Terraform\n        Creating a CI/CD workflow\n    Playing with Building Blocks — 20%\n        Leveraging AWS Cloud Components for Delivery\n        Using Environment Variables and keeping Secrets\n    Scaling Considerations, Load Balancers and CDNs — 20%\n        Many routes behind one URL\n        Enable effective caching\n        Keep things on a need to know basis (only pass what you need)\n    Load Testing — 10%\n        Build test plans with Locust.io (Python powered!)\n        Testing and debugging load tests with remote PDB\n    Conclusion — 10%\n",
+  "duration": 2409,
+  "language": "eng",
+  "recorded": "2021-06-03",
+  "related_urls": [
+    {
+      "label": "Talk announcement",
+      "url": "https://2021.djangocon.eu/cfp/talk/UBAQPR/index.html"
+    }
+  ],
+  "speakers": [
+    "Calvin Hendryx-Parker"
+  ],
+  "tags": [
+    "Django",
+    "DjangoConEU",
+    "djangoconeu2021"
+  ],
+  "thumbnail_url": "https://img.youtube.com/vi/XdH6urrt0F8/0.jpg",
+  "title": "Deploying a Django Virtual Event Platform Using Containers and Terraform",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=XdH6urrt0F8"
+    }
+  ]
+}

--- a/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-django-sketchnoting-challenge-sara-peeters.json
+++ b/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-django-sketchnoting-challenge-sara-peeters.json
@@ -1,0 +1,36 @@
+{
+  "description": "\n\nSketchnoting is the process of taking visual notes by combining symbolic illustrations and text. In this workshop we will learn the basics of sketchnoting first. And then we will make visual notes about Django concepts! Grab a pencil and some paper, and let's sketch!\n\nIn this workshop we will learn some easy drawing skills we can use for illustrating tech concepts (or anything else). Sketchnoting, the combination of text and simple, symbolic drawings is a great way to express ideas. Requirements, user stories, notes of meetings, talks, articles or tutorials, all can become much more engaging with a few extra illustrations. Though developers (and people in general) often think they can't draw, there are some easy tricks everyone can learn. In addition, drawing things is a really fun way to spend your time!\n\nAfter a short intro of what sketchnoting is (5 min), we go over 4 tips for sketching practice:\n\n    I can't draw this: composition and googling (5 min)\n    drawing people fast and easy (5 min)\n    putting text in boxes (5 min)\n    faces and emotions (5 min)\n\nWe will continue with a couple of drawing challenges (10 min), where I will show how to quickly sketch some easy and more difficult concepts.\n\nThe last 25 minutes will encourage the attendees to illustrate a Django concept on their own, with guidance and support from myself.\nThis can be the take aways of a Djangocon talk, a concept they recently learned, an illustration to a blogpost or podcast, tips on how to make the most out of an online conference...\n\nThis workshop intends to appeal to an audience of all backgrounds and skill levels. On top of that, the content will be appropriate for all ages, so you can draw along with your kids! By the end of this talk, attendees will have some inputs to be creative with pen and paper, and have learned some of the skills that go with it.",
+  "duration": 2272,
+  "language": "eng",
+  "recorded": "2021-06-02",
+  "related_urls": [
+    {
+      "label": "Talk announcement",
+      "url": "https://2021.djangocon.eu/cfp/talk/UQVXM9/index.html"
+    },
+    {
+      "label": "Tutorial",
+      "url": "https://github.com/djangocon/2021.djangocon.eu/blob/static_dump/cfp-media/tutorial.pdf?raw=true"
+    },
+    {
+      "label": "Presentation",
+      "url": "https://github.com/djangocon/2021.djangocon.eu/blob/static_dump/cfp-media/Sketchnote_talk.pdf?raw=true"
+    }
+  ],
+  "speakers": [
+    "Sara Peeters "
+  ],
+  "tags": [
+    "Django",
+    "DjangoConEU",
+    "djangoconeu2021"
+  ],
+  "thumbnail_url": "https://img.youtube.com/vi/Xn6F0wT405Q/0.jpg",
+  "title": "Django Sketchnoting Challenge",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=Xn6F0wT405Q"
+    }
+  ]
+}

--- a/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-django-unstuck-johannes-spielmann.json
+++ b/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-django-unstuck-johannes-spielmann.json
@@ -1,0 +1,28 @@
+{
+  "description": "\n\nThere are some challenges that come up in every Django project. Some of them right at the start: How do I organize my apps? Where do I put the base template, and all the other templates? Should I do internationalization right away?\nOther problems only crop up a little later: how do I manage production settings? How do I make sure permissions are checked correctly? How do I make menus appear correctly?\nSome may appear at any point in time: how do I add content pages? What code goes into models/controllers/views?\n\nIn this workshop, I'm going to tell you how I approach these recurring challenges and what my \"best practices\" in these situations are.\n\nIn this workshop, we are going to look at four challenges that appear in every Django project at some point. We are going to analyse what's happening, what you can do to get un-stuck, and see what other people do.\n\nThis workshop is for beginners and advanced Django users. The issues we discuss appear in many Django projects, so there is something here for every level of Django knowledge.\n\nThese are the four challenges we are going to look at:\n\n    App management and placement (and urlpatterns)\n    Templates: Placement, folders, blocks and inheritance and namespaces\n    When to use Middlewares and context processors and what are they?\n    Should code/logic go into models, views or managers or somewhere else?\n\nFor each of these, we will try out what I do when they happen, and we'll discuss other strategies.\n\nWe will not do a lot of coding in this workshop, but if you want to follow along, make sure you have Django installed and can execute \"django-admin.py\". There is also a set of base templates I am going to use for illustration, which is linked in the files below.\n\nOf course, there are many more problems like these, which is why I made a list of \"suggestions\" or \"best practices\" for these and others.\nHere's what we're working on so far:\n\n    App management and placement (and urlpatterns)\n    Splitting settings: local, dev, testing and production\n    Username vs email address\n    Registration in general\n    Background tasks and long-running processes and Caching\n    Templates: Placement, folders, blocks and inheritance and namespaces\n    Should you do i18n and l10n right away?\n    When and how to start caching (memcached, redis etc.)\n    Should code/logic go into models, views or managers or somewhere else?\n    When to use Middlewares and context processors and what are they?\n    How to secure access: security middlewares or login_required (white vs black list)\n    How to create files and store them in file models\n    What to do about image scaling and thumbnailing (and hosting)?\n    How to serve content: coded pages, flatpages or Wagtail?\n\nYou can find that list on Github at: https://github.com/shezi/django-unstuck (it's a work-in-progress).\nThere is also a Discord community and Telegram chat group surrounding that list, so if you have any kind of problem with a Django project, come join us and we'll find a way to get you unstuck.\n\nWe're building a community around Django best practices and on getting you Unstuck in challenging situations. Join us on Discord at https://discord.gg/bUsu9B6Ek6 or on Telegram at https://t.me/djangoRhein\n\nAbout me: I'm Johannes Spielmann, software developer-for-hire from Germany, and I've been doing Django projects for almost 15 years, ever since I saw Adrian Holovaty's presentation at \"Snakes and Rubies\". I've done projects both small and large, both in commercial and non-commercial settings, and I've seen all of the above things many times.",
+  "duration": 3766,
+  "language": "eng",
+  "recorded": "2021-06-03",
+  "related_urls": [
+    {
+      "label": "Talk announcement",
+      "url": "https://2021.djangocon.eu/cfp/talk/RW9FVH/index.html"
+    }
+  ],
+  "speakers": [
+    "Johannes Spielmann"
+  ],
+  "tags": [
+    "Django",
+    "DjangoConEU",
+    "djangoconeu2021"
+  ],
+  "thumbnail_url": "https://img.youtube.com/vi/uetyOZeVrOE/0.jpg",
+  "title": "Django Unstuck: Suggestions for common challenges in your projects",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=uetyOZeVrOE"
+    }
+  ]
+}

--- a/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-from-development-to-production-getting-actionable-insights-jerome-vieilledent.json
+++ b/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-from-development-to-production-getting-actionable-insights-jerome-vieilledent.json
@@ -1,0 +1,28 @@
+{
+  "description": "\n\nBlackfire offers a unique blend of Monitoring and Profiling features. Unlike traditional APMs on the market, it focuses on the quality of the data it collects, rather than its quantity, in order to make sure developers know quickly what they can do to fix issues.\n\nWe’ll see how developers can see in real-time how end-user perceive the performance of an application, and the several levels through which Blackfire can drill down in order to find the root cause of issues.\nWe’ll see how Blackfire can be used within CI/CD or any testing pipeline, to prevent issues from being released to production.\nAnd we’ll see how Blackfire can be used on a development machine to reproduce and analyze issues, as well as validate code iterations.",
+  "duration": 2034,
+  "language": "eng",
+  "recorded": "2021-06-04",
+  "related_urls": [
+    {
+      "label": "Talk announcement",
+      "url": "https://2021.djangocon.eu/cfp/talk/39Z3PC/index.html"
+    }
+  ],
+  "speakers": [
+    "Jérôme Vieilledent"
+  ],
+  "tags": [
+    "Django",
+    "DjangoConEU",
+    "djangoconeu2021"
+  ],
+  "thumbnail_url": "https://img.youtube.com/vi/yv_6bTdg-JU/0.jpg",
+  "title": "From Development to Production, Getting Actionable Insights to Optimize Django Code Performance",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=yv_6bTdg-JU"
+    }
+  ]
+}

--- a/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-getting-started-with-react-graphQL-and-django-aaron-bassett.json
+++ b/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-getting-started-with-react-graphQL-and-django-aaron-bassett.json
@@ -1,0 +1,28 @@
+{
+  "description": "\n\nWhat is GraphQL? When would I use it instead of DRF? How does it work with my models? In this session, we'll answer all these questions and more as we walk through a working example of a React, GraphQL, and Django application.\n\nWhen I first heard of GraphQL, I had a lot of questions. How is GraphQL different from REST? What're the benefits? When would I use it instead of DRF (Django Rest Framework)? Can I use it with my existing Django models? What about my views? My permissions? Is it difficult to integrate with my frontend?\n\nREST has served us well for more than twenty years; of course, I would be wary of any technology which requires a total paradigm shift. In this session, I will answer those questions and hopefully alleviate any apprehension about trying GraphQL.\n\nWe'll look at a working example of an RGD stack, showing how you can continue to use all the power of your Django backend while rendering and querying your data in React via GraphQL.",
+  "duration": 3829,
+  "language": "eng",
+  "recorded": "2021-06-02",
+  "related_urls": [
+    {
+      "label": "Talk announcement",
+      "url": "https://2021.djangocon.eu/cfp/talk/LMWU8L/index.html"
+    }
+  ],
+  "speakers": [
+    "Aaron Bassett"
+  ],
+  "tags": [
+    "Django",
+    "DjangoConEU",
+    "djangoconeu2021"
+  ],
+  "thumbnail_url": "https://img.youtube.com/vi/gjNMglAVCXg/0.jpg",
+  "title": "Getting started with React, GraphQL, and Django",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=gjNMglAVCXg"
+    }
+  ]
+}

--- a/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-managing-multiple-django-services-in-a-single-repo-benjy-weinberger.json
+++ b/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-managing-multiple-django-services-in-a-single-repo-benjy-weinberger.json
@@ -1,0 +1,28 @@
+{
+  "description": "\n\nDjango projects are standalone by nature, but with the right tooling and practices you can effectively maintain many interrelated Django services in a single streamlined repo, with minimal boilerplate and copypasta.\n\nModern software systems often involve developing and deploying multiple related services. The microservice architecture is a prominent example of this. These services often share underlying data structures, models, utilities, protocols and other core code.\n\nDjango is an excellent choice for building individual services, and some functionality can be shared between them by reusing apps. But Django projects themselves are standalone by nature, and there is no standard infrastructure for streamlining the management many related services. As a result we're often forced to treat each project as an island, with its own settings and deployment configuration, possibly in its own repo.\n\nIn this workshop we will demonstrate:\n- The challenges of maintaining many interrelated Django projects.\n- The advantages of having multiple Django projects coexist in a single shared repo.\n- The tooling you need to work effectively in a Django monorepo, with a focus on the Pants build system.\n- Specific examples of good practices that allow you to maintain a growing yet streamlined stable of interrelated Django-based microservices with minimal boilerplate and copypasta.\n\nCode along with us, and ask questions along the way!",
+  "duration": 3374,
+  "language": "eng",
+  "recorded": "2021-06-03",
+  "related_urls": [
+    {
+      "label": "Talk announcement",
+      "url": "https://2021.djangocon.eu/cfp/talk/CTXYZE/index.html"
+    }
+  ],
+  "speakers": [
+    "Benjy Weinberger"
+  ],
+  "tags": [
+    "Django",
+    "DjangoConEU",
+    "djangoconeu2021"
+  ],
+  "thumbnail_url": "https://img.youtube.com/vi/Glillzb_TqQ/0.jpg",
+  "title": "Managing multiple Django services in a single repo",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=Glillzb_TqQ&ab_channel=DjangoConEurope"
+    }
+  ]
+}

--- a/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-migrations-and-understanding-djangos-relationship-with-its-database-david-wobrock.json
+++ b/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-migrations-and-understanding-djangos-relationship-with-its-database-david-wobrock.json
@@ -1,0 +1,28 @@
+{
+  "description": "\n\nDo IntegrityError: NOT NULL constraint failed, column cannot be null or OperationalError: no such column ring a bell? Most Django developers experience those either during development, or worse, in production. We'll explore the whys and wherefores of these problems and suggest some solutions in order to improve your experience with Django migrations and make them seamless.\n\nSlides: https://drive.google.com/file/d/13wsg1yYWX0aJrLuA4a-GRnej42GBN1CK/view?usp=sharing\n\nSlides: https://drive.google.com/file/d/13wsg1yYWX0aJrLuA4a-GRnej42GBN1CK/view?usp=sharing\n\nDescription\nMigrations are a very convenient aspect of the Django framework. They allow making changes to your models when needed, and impact the database schema iteratively in a smooth and integrated manner. No need to have a deep knowledge of SQL, be a database expert nor administrator - it just works. Or at least, most of the time.\n\nThe generated migration files reflect the model changes from one version to the next, and Django logically expects these migrations to be applied for the database connections to work.\nThe required synchronicity between code and database schema is the root of some issues one might encounter when using Django. We will dive into these issues during this workshop.\n\nWe will first explore in which cases one can run into these migration problems, and how they are intrinsically linked to this synchronicity. This will be done by creating a Django project and adding toy features to it, like any developer would do during the workday.\nAfter defining the concept of backward incompatible migrations, we will also expose some example operations and why they can turn out dangerous.\nThe workshop will go about suggesting some existing solutions to these problems: we will manually fix such an issues in development, but also explore how to prevent them from happening in a large-scale infrastructure with multiple servers.\nHopefully giving the attendees a better grasp of what is happening under the hood when something seems off with models and migrations.\n\nWorkshop preparation\nGet the toy project up and running => clone and install https://github.com/David-Wobrock/djangocon-europe-2021-migrations-workshop",
+  "duration": 3769,
+  "language": "eng",
+  "recorded": "2021-06-04",
+  "related_urls": [
+    {
+      "label": "Talk announcement",
+      "url": "https://2021.djangocon.eu/cfp/talk/VHFEDF/index.html"
+    }
+  ],
+  "speakers": [
+    "David Wobrock"
+  ],
+  "tags": [
+    "Django",
+    "DjangoConEU",
+    "djangoconeu2021"
+  ],
+  "thumbnail_url": "https://img.youtube.com/vi/WM3W2fzCBMg/0.jpg",
+  "title": "Migrations and understanding Django's relationship with its database",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=WM3W2fzCBMg"
+    }
+  ]
+}

--- a/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-profiling-django-sumer-cip-jerome-vieilledent.json
+++ b/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-profiling-django-sumer-cip-jerome-vieilledent.json
@@ -1,0 +1,29 @@
+{
+  "description": "It is difficult to improve what is not measurable! Profiling an application should always be the first step in trying to improve its performance. With this workshop, learn how to identify performance issues in your application and adopt the best profiling practices in your daily development habits. This workshop will use the Blackfire.io tool to help you identify performance leaks.",
+  "duration": 2625,
+  "language": "eng",
+  "recorded": "2021-06-03",
+  "related_urls": [
+    {
+      "label": "Talk announcement",
+      "url": "https://2021.djangocon.eu/cfp/talk/VJD9VP/index.html"
+    }
+  ],
+  "speakers": [
+    "Jérôme Vieilledent",
+    "Sümer Cip"
+  ],
+  "tags": [
+    "Django",
+    "DjangoConEU",
+    "djangoconeu2021"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/01z4hEaR4SE/hqdefault.jpg",
+  "title": "Profiling Django & Python apps",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=01z4hEaR4SE&ab_channel=DjangoConEurope"
+    }
+  ]
+}

--- a/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-teaching-cPython-turtle-graphics-and-jinja2-in-the-browser-christopher-lozinski.json
+++ b/djangocon-eu-2021/videos/djangocon-eu-2021-secondary-teaching-cPython-turtle-graphics-and-jinja2-in-the-browser-christopher-lozinski.json
@@ -1,0 +1,28 @@
+{
+  "description": "\n\nBy the end of this class you will have the tools to teach Python, Jinja2 and web development to a class of remote students.\n\nThere are many excellent free resources for learning Python, but the Forest Wiki is the only free resource for teaching Python, Jinja2 and web development in the browser.  The Forest Wiki understands and respects the relationship between the teacher and a class of students.  \n\nHere is the demo for teaching turtle graphics.\n\nHere is the cPython in the Browser Demo.\n\nThe teacher sets the assignments, the students do them.   Even when the students are working from home, the teacher can monitor their progress. If there is an issue, or during grading,  the teacher can privately comment on that student's work.    When the time is right, the teacher can check a box to publish the answers.  When the time is up, the teacher can check another box to limit new submissions.\n\nJust to be clear, this tutorial is not about teaching you Python and web development. It is about training the teachers. It is assumed that you already know some Python and HTML. And yes, you will learn some Turtle graphics and Jinja2. But in the class the focus will be on teaching someone else. We will break out into groups of 2 and take turns being the teacher and the student.\n\nNo need to install anything for this class. All exercises will be done in the browser using Skulpt, and Pyodide (cPython 3.8.2 running on WASM). The whole point of teaching in the browser, is that your students will also not need to install anything.",
+  "duration": 748,
+  "language": "eng",
+  "recorded": "2021-06-02",
+  "related_urls": [
+    {
+      "label": "Talk announcement",
+      "url": "https://2021.djangocon.eu/cfp/talk/YXVTVE/index.html"
+    }
+  ],
+  "speakers": [
+    "Christopher Lozinski"
+  ],
+  "tags": [
+    "Django",
+    "DjangoConEU",
+    "djangoconeu2021"
+  ],
+  "thumbnail_url": "https://img.youtube.com/vi/4yH0TUnlPwU/0.jpg",
+  "title": "Teaching cPython, Turtle Graphics, and Jinja2 in the Browser",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=4yH0TUnlPwU"
+    }
+  ]
+}


### PR DESCRIPTION
During Djangocon 2021 there was a secondary track of talks. These were billed as "Workshops", but most of these were structured like regular talks, and were recorded in any case (since the entire conference was remote). So I think they warrant inclusion into PyVideos.

See them on the schedule here: https://2021.djangocon.eu/cfp/schedule/index.html#2021-06-02