### PR TITLE
Add PyDay Hurlingham 2024

### DIFF
--- a/pyday-hurlingham-2024/category.json
+++ b/pyday-hurlingham-2024/category.json
@@ -1,0 +1,3 @@
+{
+  "title": "PyDay Hurlingham 2024"
+}

--- a/pyday-hurlingham-2024/videos/ansible-101-todo-lo-que-necesitas-saber-para-automatizar-santiago-said-pydayhurlingham-2024.json
+++ b/pyday-hurlingham-2024/videos/ansible-101-todo-lo-que-necesitas-saber-para-automatizar-santiago-said-pydayhurlingham-2024.json
@@ -1,0 +1,28 @@
+{
+  "description": "Conceptos fundamentales y luego avanzamos hasta lograr construir un playbook que configure un servidor.\n\nhttps://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/615/",
+  "duration": 1680,
+  "language": "spa",
+  "recorded": "2024-10-26",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://unahur.edu.ar/llega-el-python-day-a-unahur/"
+    },
+    {
+      "label": "https://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/615/",
+      "url": "https://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/615/"
+    }
+  ],
+  "speakers": [
+    "Santiago Said"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi_webp/XB25N9tB5eA/maxresdefault.webp",
+  "title": "Ansible 101 todo lo que necesitas saber para automatizar",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=XB25N9tB5eA"
+    }
+  ]
+}

--- a/pyday-hurlingham-2024/videos/codigo-de-vortices-discretos-pablo-zitelli-pydayhurlingham-2024.json
+++ b/pyday-hurlingham-2024/videos/codigo-de-vortices-discretos-pablo-zitelli-pydayhurlingham-2024.json
@@ -1,0 +1,28 @@
+{
+  "description": "Objetivos y motivación del proyecto. Introducción al método de paneles. Descripción del proyecto.\n\nhttps://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/618/",
+  "duration": 2135,
+  "language": "spa",
+  "recorded": "2024-10-26",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://unahur.edu.ar/llega-el-python-day-a-unahur/"
+    },
+    {
+      "label": "https://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/618/",
+      "url": "https://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/618/"
+    }
+  ],
+  "speakers": [
+    "Pablo Zitelli"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/p27oINYHFZQ/maxresdefault.jpg",
+  "title": "Código de vórtices discretos",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=p27oINYHFZQ"
+    }
+  ]
+}

--- a/pyday-hurlingham-2024/videos/dando-vida-a-los-datos-python-en-bioinformatica-mercedes-didier-garnham-pydayhurlingham-2024.json
+++ b/pyday-hurlingham-2024/videos/dando-vida-a-los-datos-python-en-bioinformatica-mercedes-didier-garnham-pydayhurlingham-2024.json
@@ -1,0 +1,28 @@
+{
+  "description": "En esta charla introductoria, exploraremos cómo Python se ha consolidado como una herramienta esencial en la bioinformática.\n\nhttps://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/624/",
+  "duration": 1350,
+  "language": "spa",
+  "recorded": "2024-10-26",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://unahur.edu.ar/llega-el-python-day-a-unahur/"
+    },
+    {
+      "label": "https://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/624/",
+      "url": "https://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/624/"
+    }
+  ],
+  "speakers": [
+    "Mercedes Didier Garnham"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/CLCCuon2o9I/maxresdefault.jpg",
+  "title": "Dando vida a los datos python en bioinformática",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=CLCCuon2o9I"
+    }
+  ]
+}

--- a/pyday-hurlingham-2024/videos/ensenar-a-programar-con-python-o-con-python-ensenar-a-programar-lucas-spigariol-pydayhurlingham.json
+++ b/pyday-hurlingham-2024/videos/ensenar-a-programar-con-python-o-con-python-ensenar-a-programar-lucas-spigariol-pydayhurlingham.json
@@ -1,0 +1,28 @@
+{
+  "description": "Charla sobre cómo enseñar conceptos de programación en la Universidad utilizando Python como herramienta didáctica.\n\nhttps://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/619/",
+  "duration": 1580,
+  "language": "spa",
+  "recorded": "2024-10-26",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://unahur.edu.ar/llega-el-python-day-a-unahur/"
+    },
+    {
+      "label": "https://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/619/",
+      "url": "https://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/619/"
+    }
+  ],
+  "speakers": [
+    "Lucas Spigariol"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi_webp/Puq4w2gsIOU/maxresdefault.webp",
+  "title": "¿Enseñar a programar con python o con python enseñar a programar?",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=Puq4w2gsIOU"
+    }
+  ]
+}

--- a/pyday-hurlingham-2024/videos/eventol-tools-osiux-pydayhurlingham-2024.json
+++ b/pyday-hurlingham-2024/videos/eventol-tools-osiux-pydayhurlingham-2024.json
@@ -1,0 +1,28 @@
+{
+  "description": "Presentación de Eventol Tools por OSiUX en el PyDay Hurlingham 2024 en la UNAHUR\n\nhttps://gitlab.com/osiux/eventol-tools",
+  "duration": 290,
+  "language": "spa",
+  "recorded": "2024-10-26",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://unahur.edu.ar/llega-el-python-day-a-unahur/"
+    },
+    {
+      "label": "https://gitlab.com/osiux/eventol-tools",
+      "url": "https://gitlab.com/osiux/eventol-tools"
+    }
+  ],
+  "speakers": [
+    "OSiUX"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi_webp/u6pQ3ZedZc0/maxresdefault.webp",
+  "title": "Eventol Tools",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=u6pQ3ZedZc0"
+    }
+  ]
+}

--- a/pyday-hurlingham-2024/videos/gentil-introduccion-al-mundo-asincronico-facundo-batista-pydayhurlingham-2024.json
+++ b/pyday-hurlingham-2024/videos/gentil-introduccion-al-mundo-asincronico-facundo-batista-pydayhurlingham-2024.json
@@ -1,0 +1,28 @@
+{
+  "description": "Una historia del por qué y el cómo del mundo asincrónico, que apunta a hacer entender las bases de esta tecnología permitiendo una exploración y aprendizaje posteriores.\n\nhttps://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/608/",
+  "duration": 3273,
+  "language": "spa",
+  "recorded": "2024-10-26",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://unahur.edu.ar/llega-el-python-day-a-unahur/"
+    },
+    {
+      "label": "https://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/608/",
+      "url": "https://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/608/"
+    }
+  ],
+  "speakers": [
+    "Facundo Batista"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/D4V4M-RduLY/maxresdefault.jpg",
+  "title": "Gentil introducción al mundo asincrónico",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=D4V4M-RduLY"
+    }
+  ]
+}

--- a/pyday-hurlingham-2024/videos/juegos-en-un-ventilador-con-micropython-alejandro-j-cura-pydayhurlingham-2024.json
+++ b/pyday-hurlingham-2024/videos/juegos-en-un-ventilador-con-micropython-alejandro-j-cura-pydayhurlingham-2024.json
@@ -1,0 +1,28 @@
+{
+  "description": "Micropython fue usado para fabricar Ventilastation, la consola de videojuegos argentina hecha con LEDs, un microcontrolador ESP32 y un ventilador de 30 pulgadas. En esta charla explicaremos cómo funciona esta consola, y cómo usar Micropython para hacer tus propios juegos.\n\nhttps://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/610/",
+  "duration": 3480,
+  "language": "spa",
+  "recorded": "2024-10-26",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://unahur.edu.ar/llega-el-python-day-a-unahur/"
+    },
+    {
+      "label": "https://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/610/",
+      "url": "https://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/610/"
+    }
+  ],
+  "speakers": [
+    "Alejandro J Cura"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/8yWTWJdrpBc/maxresdefault.jpg",
+  "title": "Juegos en un ventilador con MicroPython",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=8yWTWJdrpBc"
+    }
+  ]
+}

--- a/pyday-hurlingham-2024/videos/programacion-creativa-con-retro-python-hugo-ruscitti-pydayhurlingham-2024.json
+++ b/pyday-hurlingham-2024/videos/programacion-creativa-con-retro-python-hugo-ruscitti-pydayhurlingham-2024.json
@@ -1,0 +1,28 @@
+{
+  "description": "Exploraremos conceptos básicos sobre cómo dibujar en pantalla, crear juegos y animaciones usando python en el navegador.\n\nhttps://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/609/",
+  "duration": 1500,
+  "language": "spa",
+  "recorded": "2024-10-26",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://unahur.edu.ar/llega-el-python-day-a-unahur/"
+    },
+    {
+      "label": "https://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/609/",
+      "url": "https://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/609/"
+    }
+  ],
+  "speakers": [
+    "Hugo Ruscitti"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/XdFKyMEbBUA/maxresdefault.jpg",
+  "title": "Programación creativa con retro python",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=XdFKyMEbBUA"
+    }
+  ]
+}

--- a/pyday-hurlingham-2024/videos/pycurl-no-es-tan-complicado-como-dicen-ignacio-feijoo-pydayhurlingham-2024.json
+++ b/pyday-hurlingham-2024/videos/pycurl-no-es-tan-complicado-como-dicen-ignacio-feijoo-pydayhurlingham-2024.json
@@ -1,0 +1,28 @@
+{
+  "description": "Desmitificando la complejidad de pycurl. Veremos cómo implementar una breve clase para ejecutar los verbos mas comunes de http.\n\nhttps://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/614/",
+  "duration": 1280,
+  "language": "spa",
+  "recorded": "2024-10-26",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://unahur.edu.ar/llega-el-python-day-a-unahur/"
+    },
+    {
+      "label": "https://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/614/",
+      "url": "https://eventos.python.org.ar/events/pyday-hurlingham-2024/activity/614/"
+    }
+  ],
+  "speakers": [
+    "Ignacio Feijoo"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/7HcK5Ut5Erw/maxresdefault.jpg",
+  "title": "pycurl no es tan complicado como dicen",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=7HcK5Ut5Erw"
+    }
+  ]
+}


### PR DESCRIPTION
- Introduce JSON files for each presentation at PyDay Hurlingham 2024.
- Include details such as title, description, duration, language,
  recorded date, related URLs, speakers, and video links.