### PR TITLE
Add PyDay Chile 2022

### DIFF
--- a/pyday-chile-2022/category.json
+++ b/pyday-chile-2022/category.json
@@ -1,0 +1,3 @@
+{
+  "title": "PyDay Chile 2022"
+}

--- a/pyday-chile-2022/videos/a-review-and-application-of-disease-informed-neural-network.json
+++ b/pyday-chile-2022/videos/a-review-and-application-of-disease-informed-neural-network.json
@@ -1,0 +1,28 @@
+{
+  "description": "Este trabajo es una aplicacón de Disease Informed Neural Networks (DINN) , las cuales se emplear para predecir de manera efectiva la propagación de enfermedades infecciosas. Este enfoque se basa en el éxito Physics Informed Neural Networks (PINN) que se han aplicado a una variedad de áreas y pueden modelar ecuaciones diferenciales parciales y ordinarias, tanto lineales y como no lineales.\n\nLa presentación consiste de una pequeña introducción a PINN y experimentos computacionales que sugieren que DINNs es un candidato confiable para aprender de manera efectiva sobre la dinámica de propagación y pronosticar su progresión en el futuro a partir de los datos disponibles del mundo real.\n\nSe ha utilizado la librería DeepXDE (https://deepxde.readthedocs.io/en/latest/) como framework de modelamiento y predicción a través de redes neuronales.\n\nPonente:  Alonso Ogueda\nlinkedin: linkedin.com/in/aoguedaoliva/\nblog: aoguedao.github.io",
+  "duration": 1266,
+  "language": "spa",
+  "recorded": "2022-07-15",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://pyday.cl/2022/"
+    },
+    {
+      "label": "https://deepxde.readthedocs.io/en/latest/",
+      "url": "https://deepxde.readthedocs.io/en/latest/"
+    }
+  ],
+  "speakers": [
+    "Alonso Ogueda"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi_webp/H4V_piDTCdY/maxresdefault.webp",
+  "title": "A Review and Application of Disease Informed Neural Network",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=H4V_piDTCdY"
+    }
+  ]
+}

--- a/pyday-chile-2022/videos/charlas-relampago-y-cierre-del-evento.json
+++ b/pyday-chile-2022/videos/charlas-relampago-y-cierre-del-evento.json
@@ -1,0 +1,27 @@
+{
+  "description": "",
+  "duration": 2055,
+  "language": "spa",
+  "recorded": "2022-07-15",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://pyday.cl/2022/"
+    }
+  ],
+  "speakers": [
+    "Cesar Arnaez", 
+    "Claudio Piña",
+    "Leonardo Guedez",
+    "Denny Perez"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/OwSdo5aorXI/maxresdefault.jpg",
+  "title": "Charlas Relámpago",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=OwSdo5aorXI"
+    }
+  ]
+}

--- a/pyday-chile-2022/videos/clases-interactivas-con-google-colab-mkdocs-y-github-actions.json
+++ b/pyday-chile-2022/videos/clases-interactivas-con-google-colab-mkdocs-y-github-actions.json
@@ -1,0 +1,24 @@
+{
+  "description": "La presentación tiene como objetivo encontrar una forma innovadora de documentar objetos tipo Jupyter Notebook con las herrramientas: mkdocs, Github Actions y Google Colab.\n\nLo primero será explicar un poco acerca de estas herramientas (en lo posible compararla con herramientas similares) y justificar por qué esta es una buena alternativa, luego poner manos a las obras aplicando esta herramientas mediante un ejemplo aplicado y finalmente mostrar un par de ejemplos personales.\n\nPonente: Francisco Alfaro\n linkedin: linkedin.com/in/faam/\n blog: fralfaro.github.io/portfolio",
+  "duration": 1425,
+  "language": "spa",
+  "recorded": "2022-07-15",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://pyday.cl/2022/"
+    }
+  ],
+  "speakers": [
+    "Francisco Alfaro"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/GON2Jb-uiGg/maxresdefault.jpg",
+  "title": "Clases Interactivas con Google Colab, Mkdocs y Github Actions",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=GON2Jb-uiGg"
+    }
+  ]
+}

--- a/pyday-chile-2022/videos/como-potenciar-el-marketing-de-tu-empresa-utilizando-odoo-python.json
+++ b/pyday-chile-2022/videos/como-potenciar-el-marketing-de-tu-empresa-utilizando-odoo-python.json
@@ -1,0 +1,24 @@
+{
+  "description": "Breve introducción de las alternativas que ofrece Odoo para potenciar el marketing digital en tu empresa y como potenciar su comportamiento con Python.\n\nPonente: Eladio García",
+  "duration": 1492,
+  "language": "spa",
+  "recorded": "2022-07-15",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://pyday.cl/2022/"
+    }
+  ],
+  "speakers": [
+    "Eladio García"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi_webp/QLtxDNdaf2M/maxresdefault.webp",
+  "title": "Como potenciar el marketing de tu empresa utilizando Odoo y Python",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=QLtxDNdaf2M"
+    }
+  ]
+}

--- a/pyday-chile-2022/videos/comunidades-pyladies-chile-santiago-y-valparaiso.json
+++ b/pyday-chile-2022/videos/comunidades-pyladies-chile-santiago-y-valparaiso.json
@@ -1,0 +1,24 @@
+{
+  "description": "Esta es una sesión donde presentaremos el capítulo de PyLadies Santiago y a la vez haremos el lanzamiento oficial de PyLadies Valparaiso. Estaremos presentando diapositivas con información de ambos capítulos y presentando las organizadoras de los mismos.",
+  "duration": 1229,
+  "language": "spa",
+  "recorded": "2022-07-15",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://pyday.cl/2022/"
+    }
+  ],
+  "speakers": [
+    "Denny Perez"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/YJ5f_NwBZRM/maxresdefault.jpg",
+  "title": "Comunidades Pyladies Chile: Santiago y Valparaíso",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=YJ5f_NwBZRM"
+    }
+  ]
+}

--- a/pyday-chile-2022/videos/construyendo-nuestra-torre-de-babel-django-singer-etl-airflow-otro-proceso-etl-mas.json
+++ b/pyday-chile-2022/videos/construyendo-nuestra-torre-de-babel-django-singer-etl-airflow-otro-proceso-etl-mas.json
@@ -1,0 +1,24 @@
+{
+  "description": "El mundo como lo conocemos actualmente es un compendio de datos distribuidos entre distintas fuentes y bases de datos que a efectos prácticos necesita ser centralizada para su posterior análisis.\n\nEsta charla explora de forma general, una alternativa para estandarizar la extracción de datos utilizando Singer ETL y Apache Airflow para la automatización de los flujos de trabajo.\n\nPonente: Juan Perozo\n  linkedin.com/in/jperozo89/",
+  "duration": 832,
+  "language": "spa",
+  "recorded": "2022-07-15",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://pyday.cl/2022/"
+    }
+  ],
+  "speakers": [
+    "Juan Perozo"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi_webp/qL1QyZFiUtk/maxresdefault.webp",
+  "title": "Construyendo nuestra torre de Babel: Django + Singer ETL + Airflow. Otro proceso ETL mas.",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=qL1QyZFiUtk"
+    }
+  ]
+}

--- a/pyday-chile-2022/videos/decoradores-para-mejorar-el-codigo.json
+++ b/pyday-chile-2022/videos/decoradores-para-mejorar-el-codigo.json
@@ -1,0 +1,24 @@
+{
+  "description": "En esta charla hablaremos del uso de decoradores y su ejemplo en código para data science en producción.\n\nTratará sobre el uso que le podemos dar a decoradores para encadenar funciones que usamos regularmente, como por ejemplo, mapeos de uso de memoria, toma de tiempo de funciones, calculo de estado  en funciones que entreguen dataframes.\n\nPonente:  César Hormazábal\nlinkedin:   linkedin.com/in/hormazabalcesar/",
+  "duration": 895,
+  "language": "spa",
+  "recorded": "2022-07-15",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://pyday.cl/2022/"
+    }
+  ],
+  "speakers": [
+    "César Hormazábal"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi_webp/idfhH06DQyU/maxresdefault.webp",
+  "title": "Decoradores para mejorar el código",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=idfhH06DQyU"
+    }
+  ]
+}

--- a/pyday-chile-2022/videos/exploracion-de-datos-con-python.json
+++ b/pyday-chile-2022/videos/exploracion-de-datos-con-python.json
@@ -1,0 +1,24 @@
+{
+  "description": "Los datos buenos y bien pre procesados son incluso más importantes que los algoritmos más potentes y dependiendo de las técnicas y fuentes de recopilación de datos, puede terminar con datos que están fuera de rango o incluyen una característica incorrecta, para quienes tienen problemas programar python es un gran alivio, permite indexar, manipular, imputar archivos faltantes, clasificar y fusionar marcos de datos.\n\nPonente: Estephani Rivera Jaramillo\ntwitter: @estephani_jusep\nlinkedin:  linkedin.com/in/estephani-rivera-jaramillo-83224146/",
+  "duration": 1379,
+  "language": "spa",
+  "recorded": "2022-07-15",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://pyday.cl/2022/"
+    }
+  ],
+  "speakers": [
+    "Estephani Rivera Jaramillo"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi_webp/a6wZgfmgRSY/maxresdefault.webp",
+  "title": "Exploración de Datos con Python",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=a6wZgfmgRSY"
+    }
+  ]
+}

--- a/pyday-chile-2022/videos/inteligencia-artificial-para-prevenir-el-dengue-zika-y-chikungunya.json
+++ b/pyday-chile-2022/videos/inteligencia-artificial-para-prevenir-el-dengue-zika-y-chikungunya.json
@@ -1,0 +1,28 @@
+{
+  "description": "El objetivo poder entender como funciona la de detección de objetos ( yolov5), desde el armado dela base de datos, hasta llevarlo a producción usando el caso de trampas Bareló; Sistema de iot e IA para reconocer y detectar el Aedes aegypti.\n\nRecursos:\nhttps://github.com/Municipalidad-de-Vicente-Lopez/Trampa_Barcelo\n\nPonente: Cesar Riat \n  twitter: @cesarriat\n  linkedin: linkedin.com/in/cesar-riat/\n  blog: linktr.ee/cesarriat \n  empresa: allaideas.com",
+  "duration": 1238,
+  "language": "spa",
+  "recorded": "2022-07-15",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://pyday.cl/2022/"
+    },
+    {
+      "label": "https://github.com/Municipalidad-de-Vicente-Lopez/Trampa_Barcelo",
+      "url": "https://github.com/Municipalidad-de-Vicente-Lopez/Trampa_Barcelo"
+    }
+  ],
+  "speakers": [
+    "Cesar Riat"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/o2m9ePOkcN0/maxresdefault.jpg",
+  "title": "Inteligencia Artificial para prevenir el Dengue, Zika y Chikungunya",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=o2m9ePOkcN0"
+    }
+  ]
+}

--- a/pyday-chile-2022/videos/introduccion-a-rmarkdown-creando-reportes-con-python-en-rstudio.json
+++ b/pyday-chile-2022/videos/introduccion-a-rmarkdown-creando-reportes-con-python-en-rstudio.json
@@ -1,0 +1,32 @@
+{
+  "description": "RMarkdown permite tomar tu código de Python y convertirlo en documentos reproducibles en formatos tales como HTML, PDF, Microsoft Word y otros y poder publicarlos en plataformas tales como Rpubs o Netlify; RMarkdown te permite trabajar con todas las librerías de Python.\n\nNotas:\n\nEl asistente necesita tener instalado en su equipo:\n\nLenguajes de programación:\n\n- Python 3.10x, en su defecto Anaconda\n- Lenguaje de programación R 4.1.3\n- Se recomienda siempre tener la última versión de los mencionados lenguajes de programación\n\nHerramientas - paquetes - librerías:\n\n- RStudio (última versión, recomendable)\n- ggplot2\n- lattice\n- reticulate\n- matplotlib\n- Numpy\n- Folium\n\nPlataformas:\n\n- Cuenta en RPubs https://rpubs.com/\n- Cuenta en Netlify https://netlify.app/\n\nPonente: Renzo Cáceres Rossi\nTwitter: @RHablamos\nLinkedIn: linkedin.com/in/andrescaceresrossi/\nBlog: hablamosr.blogspot.com\nEmpresa: datascience.pe",
+  "duration": 1215,
+  "language": "spa",
+  "recorded": "2022-07-15",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://pyday.cl/2022/"
+    },
+    {
+      "label": "https://netlify.app/",
+      "url": "https://netlify.app/"
+    },
+    {
+      "label": "https://rpubs.com/",
+      "url": "https://rpubs.com/"
+    }
+  ],
+  "speakers": [
+    "Renzo Cáceres Rossi"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi_webp/J9EwXn_9zxc/maxresdefault.webp",
+  "title": "Introducción a RMarkdown, creando reportes con Python en RStudio",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=J9EwXn_9zxc"
+    }
+  ]
+}

--- a/pyday-chile-2022/videos/la-versatilidad-de-python.json
+++ b/pyday-chile-2022/videos/la-versatilidad-de-python.json
@@ -1,0 +1,24 @@
+{
+  "description": "La flexibilidad del lenguaje Python y su punto de fusión con diversas ramas profesionales. Como siendo estudiante de derecho, di el salto a la informática consiguiendo converger en ciberseguridad.\n\nPonente: Shaima Chachai\ntwitter: @spiralringzz\nlinkedin: linkedin.com/in/shaima-chachai-2052b9178",
+  "duration": 1380,
+  "language": "spa",
+  "recorded": "2022-07-15",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://pyday.cl/2022/"
+    }
+  ],
+  "speakers": [
+    "Shaima Chachai"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/SVjQwYhNWbA/maxresdefault.jpg",
+  "title": "La versatilidad de Python",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=SVjQwYhNWbA"
+    }
+  ]
+}

--- a/pyday-chile-2022/videos/manejo-de-imagenes-con-vision-computacional.json
+++ b/pyday-chile-2022/videos/manejo-de-imagenes-con-vision-computacional.json
@@ -1,0 +1,24 @@
+{
+  "description": "Máster en diseño y producción multimedia, Ingeniera informática, líder de la comunidad PyLadies Cochabamba, Organizadora de Python Bolivia, Instructora de programación y computación en Cisco Networking Academy.\n\nPonente:  Alison Orellana\ntwitter: @ALLY_OR_ENEMY\nlinkedin: linkedin.com/in/alison-or/\nblog: wlo.link/@AllyOR",
+  "duration": 1213,
+  "language": "spa",
+  "recorded": "2022-07-15",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://pyday.cl/2022/"
+    }
+  ],
+  "speakers": [
+    "Alison Orellana"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi_webp/1I_KIYPRymA/maxresdefault.webp",
+  "title": "Manejo de imágenes con Visión Computacional",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=1I_KIYPRymA"
+    }
+  ]
+}

--- a/pyday-chile-2022/videos/mejorando-la-confiabilidad-de-los-datos-con-dbt.json
+++ b/pyday-chile-2022/videos/mejorando-la-confiabilidad-de-los-datos-con-dbt.json
@@ -1,0 +1,24 @@
+{
+  "description": "En esta charla conocerás una introducción a data build tool (dbt), una herramienta hecha en python que ayuda a los equipos de datos a transformar, testear y documentar la data en la nube.\n\nRevisaremos los origenes de dbt, su relacion con el \"modern data stack\", sus funcionalidades y cómo implementar este framework puede ayudarte a mejorar la confiabilidad de tus datos y dejarte más tiempo para dar valor a tu negocio.\n\nPonente: Carlos Aracibia\nlinkedin:   linkedin.com/in/carancibia/",
+  "duration": 1208,
+  "language": "spa",
+  "recorded": "2022-07-15",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://pyday.cl/2022/"
+    }
+  ],
+  "speakers": [
+    "Carlos Aracibia"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi_webp/dV42WcO5pXw/maxresdefault.webp",
+  "title": "Mejorando la confiabilidad de los datos con dbt",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=dV42WcO5pXw"
+    }
+  ]
+}

--- a/pyday-chile-2022/videos/porque-todos-los-programadores-deberian-participar-en-una-comunidad.json
+++ b/pyday-chile-2022/videos/porque-todos-los-programadores-deberian-participar-en-una-comunidad.json
@@ -1,0 +1,25 @@
+{
+  "description": "Para esta presentación, queremos reflexionar sobre por qué es importante el participar en una comunidad y participar en eventos de código abierto.\n\nPor qué todos los desarrolladores deberían comenzar a hacerlo. Cada programador tiene sus propias razones para empezar a participar, pero esta es nuestra versión 1.0\n\nPonentes:\nJosé Arnulfo Reyes:\ntwitter: @arnuIfo_07\nlinkedin: linkedin.com/in/arnulfo-rh\ninstagram.com/arnulfo_07 \nmedium.com/@arnulfo \narnulforeyes.com \n\nJosé Ramírez:\ntwitter: JoseTheEngineer\nlinkedin: linkedin.com/in/jose-ramirez-4ae",
+  "duration": 1799,
+  "language": "spa",
+  "recorded": "2022-07-15",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://pyday.cl/2022/"
+    }
+  ],
+  "speakers": [
+    "José Arnulfo Reyes",
+    "José Ramírez"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/EmpVlIk65gU/maxresdefault.jpg",
+  "title": "Por qué todos los programadores deberían participar en una comunidad",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=EmpVlIk65gU"
+    }
+  ]
+}

--- a/pyday-chile-2022/videos/python-chile.json
+++ b/pyday-chile-2022/videos/python-chile.json
@@ -1,0 +1,24 @@
+{
+  "description": "La comunidad Python Chile y su evolución en los últimos dos años y hacia donde y como puede crecer en el futuro.",
+  "duration": 933,
+  "language": "spa",
+  "recorded": "2022-07-15",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://pyday.cl/2022/"
+    }
+  ],
+  "speakers": [
+    "Cristián Maureira-Fredes"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/ZWA8MzjnpUc/maxresdefault.jpg",
+  "title": "Python Chile",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=ZWA8MzjnpUc"
+    }
+  ]
+}

--- a/pyday-chile-2022/videos/python-en-ciberseguridad.json
+++ b/pyday-chile-2022/videos/python-en-ciberseguridad.json
@@ -1,0 +1,24 @@
+{
+  "description": "Demuestro desde un principio el como crear un script en Kali Linux para por ejemplo hacer un escaneo de puertos a otra maquina virtual y obtener resultados de la misma forma que lo haria un escaneo con nmap, pero sin nmap. \n\nPorque el titulo es python en ciberseguridad???? porque un script para un escaneo de puertos es bastante usado en las fases previas a las pruebas de penetracion en si. \n\nPonente: Diego Cáceres\nlinkedin: linkedin.com/in/dcaceresso/",
+  "duration": 1295,
+  "language": "spa",
+  "recorded": "2022-07-15",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://pyday.cl/2022/"
+    }
+  ],
+  "speakers": [
+    "Diego Cáceres"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi/EIsRdWhhl3M/maxresdefault.jpg",
+  "title": "Python en Ciberseguridad",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=EIsRdWhhl3M"
+    }
+  ]
+}

--- a/pyday-chile-2022/videos/uso-de-quarto-en-la-ensenanza-de-pensamiento-computacional.json
+++ b/pyday-chile-2022/videos/uso-de-quarto-en-la-ensenanza-de-pensamiento-computacional.json
@@ -1,0 +1,24 @@
+{
+  "description": "La enseñanza de pensamiento computacional es una alternativa para mejorar las habilidades y destrezas para la vida de cualquier persona. Quarto es una herramienta para escribir artículos científicos, páginas web, presentaciones, y mucho más.\n\nDejando de utilizar herramientas privativas de suit ofimítica, distribuciones que consumen muchos recursos que nunca utilizamos.\nLa gran ventaja es poder incluir código mientras se crea una diapositiva/pagina web, incluir el código, incluir la salida y todo ello desde el mismo editor.\nUtiliza el lenguaje de marcado MarkDown.\n\nTener un computador para probar lo que se pueda mostrar a traves de la charla, cuenta de github, tener instalado git, editor de código VsCode, nvim, RStudio.\nDirigido a Docentes, Científicos de Datos, Computación Científica.\n\nPonente: Diego Saavedra\ntwitter: @statick_ds\nlinkedin: ec.linkedin.com/in/diego-saavedra-3116401a7",
+  "duration": 1214,
+  "language": "spa",
+  "recorded": "2022-07-15",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://pyday.cl/2022/"
+    }
+  ],
+  "speakers": [
+    "Diego Saavedra"
+  ],
+  "tags": [],
+  "thumbnail_url": "https://i.ytimg.com/vi_webp/ohGkVdK0iXI/maxresdefault.webp",
+  "title": "Uso de Quarto en la enseñanza de pensamiento computacional.",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=ohGkVdK0iXI"
+    }
+  ]
+}


### PR DESCRIPTION
- Introduce metadata for various presentations from PyDay Chile 2022.
- Includes details such as title, description, duration, speakers,
  and related URLs for each session.