### PR TITLE
Add PyCon Latam 2020

### DIFF
--- a/pycon-latam-2020/category.json
+++ b/pycon-latam-2020/category.json
@@ -1,0 +1,3 @@
+{
+  "title": "PyCon Latam 2020"
+}

--- a/pycon-latam-2020/videos/pycon-latam-entrevista-con-alvaro-justen.json
+++ b/pycon-latam-2020/videos/pycon-latam-entrevista-con-alvaro-justen.json
@@ -1,0 +1,26 @@
+{
+  "description": "Contamos con la presencia de Álvaro Justen quien participo como Keynote en/durante PyCon Latam 2019!",
+  "duration": 1607,
+  "language": "spa",
+  "recorded": "2020-08-27",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://2020.pylatam.org/"
+    }
+  ],
+  "speakers": [
+    "Álvaro Justen"
+  ],
+  "tags": [
+    "Keynote"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/QxjTc_QcL1s/sddefault.jpg",
+  "title": "Entrevista con Álvaro Justen",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=QxjTc_QcL1s"
+    }
+  ]
+}

--- a/pycon-latam-2020/videos/pycon-latam-entrevista-con-carol-willing.json
+++ b/pycon-latam-2020/videos/pycon-latam-entrevista-con-carol-willing.json
@@ -1,0 +1,26 @@
+{
+  "description": "Tenemos una entrevista con Carol Willing y tenemos el gusto de anunciar su participación como Keynote durante la edición de PyCon Latam 2021!!",
+  "duration": 2179,
+  "language": "spa",
+  "recorded": "2020-08-27",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://2020.pylatam.org/"
+    }
+  ],
+  "speakers": [
+    "Carol Willing"
+  ],
+  "tags": [
+    "Keynote"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/KMPsy2SO0M4/sddefault.jpg",
+  "title": "Entrevista con Carol Willing",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=KMPsy2SO0M4"
+    }
+  ]
+}

--- a/pycon-latam-2020/videos/pycon-latam-entrevista-con-froilan-irizarry.json
+++ b/pycon-latam-2020/videos/pycon-latam-entrevista-con-froilan-irizarry.json
@@ -1,0 +1,26 @@
+{
+  "description": "Tenemos una entrevista con Froilán Irizarry y tenemos el gusto de anunciar su participación como Keynote durante la edición de PyCon Latam 2021!!",
+  "duration": 1711,
+  "language": "spa",
+  "recorded": "2020-08-27",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://2020.pylatam.org/"
+    }
+  ],
+  "speakers": [
+    "Froilán Irizarry"
+  ],
+  "tags": [
+    "Keynote"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/aLS3mfN_llM/sddefault.jpg",
+  "title": "Entrevista con Froilán Irizarry",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=aLS3mfN_llM"
+    }
+  ]
+}

--- a/pycon-latam-2020/videos/pycon-latam-entrevista-con-lorena-mesa.json
+++ b/pycon-latam-2020/videos/pycon-latam-entrevista-con-lorena-mesa.json
@@ -1,0 +1,26 @@
+{
+  "description": "Tenemos la presencia de Lorena Mesa quien participo como Keynote en/durante PyCon Latam 2019!",
+  "duration": 1028,
+  "language": "spa",
+  "recorded": "2020-08-27",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://2020.pylatam.org/"
+    }
+  ],
+  "speakers": [
+    "Lorena Mesa"
+  ],
+  "tags": [
+    "Keynote"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/X6qYsyCUACA/sddefault.jpg",
+  "title": "Entrevista con Lorena Mesa",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=X6qYsyCUACA"
+    }
+  ]
+}

--- a/pycon-latam-2020/videos/pycon-latam-entrevista-con-luciano-ramalho.json
+++ b/pycon-latam-2020/videos/pycon-latam-entrevista-con-luciano-ramalho.json
@@ -1,0 +1,26 @@
+{
+  "description": "Tenemos una entrevista con Luciano Ramalho y tenemos el gusto de anunciar su participación como Keynote durante la edición de PyCon Latam 2021!!",
+  "duration": 2427,
+  "language": "eng",
+  "recorded": "2020-08-27",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://2020.pylatam.org/"
+    }
+  ],
+  "speakers": [
+    "Luciano Ramalho"
+  ],
+  "tags": [
+    "Keynote"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/EC98HDMSR8Q/sddefault.jpg",
+  "title": "Entrevista con Luciano Ramalho",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=EC98HDMSR8Q"
+    }
+  ]
+}

--- a/pycon-latam-2020/videos/pycon-latam-entrevista-con-sergio-sanchez.json
+++ b/pycon-latam-2020/videos/pycon-latam-entrevista-con-sergio-sanchez.json
@@ -1,0 +1,26 @@
+{
+  "description": "Tenemos una entrevista con Sergio Sánchez, fundador de Tacos de Datos, y tenemos el gusto de anunciar su participación como Keynote durante la edición de PyCon Latam 2021!!",
+  "duration": 2372,
+  "language": "spa",
+  "recorded": "2020-08-27",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://2020.pylatam.org/"
+    }
+  ],
+  "speakers": [
+    "Sergio Sánchez"
+  ],
+  "tags": [
+    "Keynote"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/PVliND_o58c/sddefault.jpg",
+  "title": "Entrevista con Sergio Sánchez",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=PVliND_o58c"
+    }
+  ]
+}

--- a/pycon-latam-2020/videos/pycon-latam-entrevista-con-tania-allard.json
+++ b/pycon-latam-2020/videos/pycon-latam-entrevista-con-tania-allard.json
@@ -1,0 +1,26 @@
+{
+  "description": "Contamos con la presencia de Tania Allard quien participo como Keynote en/durante PyCon Latam 2019!",
+  "duration": 2532,
+  "language": "spa",
+  "recorded": "2020-08-27",
+  "related_urls": [
+    {
+      "label": "Conference Website",
+      "url": "https://2020.pylatam.org/"
+    }
+  ],
+  "speakers": [
+    "Tania Allard"
+  ],
+  "tags": [
+    "Keynote"
+  ],
+  "thumbnail_url": "https://i.ytimg.com/vi/BajgzKsHBU8/sddefault.jpg",
+  "title": "Entrevista con Tania Allard",
+  "videos": [
+    {
+      "type": "youtube",
+      "url": "https://www.youtube.com/watch?v=BajgzKsHBU8"
+    }
+  ]
+}


### PR DESCRIPTION
- Create JSON files for interviews with key speakers at
  PyCon Latam 2020, including descriptions, durations,
  languages, and related URLs.
- Add metadata for Álvaro Justen, Carol Willing,
  Froilán Irizarry, Lorena Mesa, Luciano Ramalho,
  Sergio Sánchez, and Tania Allard.