### PR TITLE
Fix grouping for PyCon APAC 2013

### DIFF
--- a/pycon-apac-2013/category.json
+++ b/pycon-apac-2013/category.json
@@ -1,3 +1,4 @@
 {
-  "title": "PyCon APAC 2013 in Japan"
+  "description": "PyCon APAC 2013 in Japan",
+  "title": "PyCon APAC 2013"
 }


### PR DESCRIPTION
PyCon APAC 2013 appears in a different row than the other year editions

![image](https://github.com/user-attachments/assets/0fcd980e-b927-4461-9c6d-9abe631e5557)