### PR TITLE
Exclude schema definition files from schema validation checks

### DIFF
--- a/.tests/schemas.py
+++ b/.tests/schemas.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import argparse
 import json
 import os
@@ -10,7 +11,10 @@ from tools.utils import get_json_files
 
 def check_schemas(data_root, schemas_dir, verbose=False):
     schemas = ('category.json', 'video.json')
-    all_file_paths = get_json_files(data_root)
+    all_file_paths = get_json_files(
+        data_root,
+        exclude=set(Path(schemas_dir).rglob('*.json')),
+    )
 
     error_count = 0
 


### PR DESCRIPTION
Currently, the category schema definition file is included in the list of files that are validated against it. This causes validation errors when the schema validation's strictness is increased, e.g. by disallowing additional properties in #1172. This change excludes schema JSON files from the schema test script to resolve future validation errors.