### PR TITLE
Allow start_date, end_date, and URL in category schema

### DIFF
--- a/.schemas/category.json
+++ b/.schemas/category.json
@@ -13,6 +13,20 @@
     "title":{
       "description":"Title of event where videos originated",
       "type":"string"
+    },
+    "url":{
+      "description":"Canonical URL to the event website",
+      "type":"string"
+    },
+    "start_date":{
+      "description":"Start date of the event in YYYY-MM-DD format",
+      "type":"string",
+      "format":"date"
+    },
+    "end_date":{
+      "description":"End date of the event in YYYY-MM-DD format",
+      "type":"string",
+      "format":"date"
     }
   },
   "required":[

--- a/djangocon-eu-2010/category.json
+++ b/djangocon-eu-2010/category.json
@@ -1,6 +1,7 @@
 {
   "description": "",
-  "start_date": null,
+  "start_date": "2010-05-24",
+  "end_date": "2010-05-26",
   "title": "DjangoCon Europe 2010",
   "url": ""
 }

--- a/pygotham-2012/category.json
+++ b/pygotham-2012/category.json
@@ -1,6 +1,7 @@
 {
   "description": "",
-  "start_date": null,
+  "start_date": "2012-06-08",
+  "end_date": "2012-06-08",
   "title": "PyGotham 2012",
   "url": ""
 }


### PR DESCRIPTION
Add start and end date fields as well as URL to the category schema. These properties are common across many categories supported here and already present in a handful of data files.

This change also populates start and end date information based on the recording dates in video files for a couple of categories that have these fields present but do not pass the JSON Schema date format validation.

References #268 and #1172.