### PR TITLE
fix: wrong video linked for Playwright testing talk

### DIFF
--- a/flaskcon-2025/videos/testing-flask-and-quart-apps-with-playwright.json
+++ b/flaskcon-2025/videos/testing-flask-and-quart-apps-with-playwright.json
@@ -17,7 +17,7 @@
   "videos": [
     {
       "type": "youtube",
-      "url": "https://www.youtube.com/watch?v=Yuj-1j7uQjM"
+      "url": "https://www.youtube.com/watch?v=U3W9V4NWbOk"
     }
   ],
   "duration": 1587,


### PR DESCRIPTION
This PR fixes the incorrect YouTube link for the talk “Testing Flask and Quart apps with Playwright”. It was previously pointing to a different video (“Adding OpenAPI to a Flask Application with APIFlask”) and now links to the correct one.